### PR TITLE
MIFOSX 26 Solidarity group loan

### DIFF
--- a/mifosng-db/patches/patch-0001-add-group_id-to-m_loan.sql
+++ b/mifosng-db/patches/patch-0001-add-group_id-to-m_loan.sql
@@ -1,0 +1,3 @@
+alter table m_loan add column group_id bigint(20) after client_id;
+alter table m_loan modify client_id bigint(20);
+alter table m_loan add constraint foreign key (`group_id`) references `m_group` (`id`);

--- a/mifosng-provider/src/main/java/org/mifosng/platform/api/GroupsApiResource.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/api/GroupsApiResource.java
@@ -20,8 +20,10 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import org.mifosng.platform.api.commands.GroupCommand;
+import org.mifosng.platform.api.data.ClientAccountSummaryCollectionData;
 import org.mifosng.platform.api.data.ClientLookup;
 import org.mifosng.platform.api.data.EntityIdentifier;
+import org.mifosng.platform.api.data.GroupAccountSummaryCollectionData;
 import org.mifosng.platform.api.data.GroupData;
 import org.mifosng.platform.api.data.OfficeLookup;
 import org.mifosng.platform.api.infrastructure.ApiDataConversionService;
@@ -166,5 +168,29 @@ public class GroupsApiResource {
         EntityIdentifier entityIdentifier = this.groupWritePlatformService.deleteGroup(groupId);
 
         return Response.ok().entity(entityIdentifier).build();
+    }
+
+    @GET
+    @Path("{groupId}/loans")
+    @Consumes({MediaType.APPLICATION_JSON})
+    @Produces({MediaType.APPLICATION_JSON})
+    public String retrieveGroupAccount(@PathParam("groupId") final Long groupId,
+                                       @Context final UriInfo uriInfo) {
+
+        Set<String> typicalResponseParameters = new HashSet<String>(
+                Arrays.asList("pendingApprovalLoans", "awaitingDisbursalLoans", "openLoans", "closedLoans",
+                        "anyLoanCount", "pendingApprovalLoanCount", "awaitingDisbursalLoanCount",
+                        "activeLoanCount", "closedLoanCount")
+        );
+
+        Set<String> responseParameters = ApiParameterHelper.extractFieldsForResponseIfProvided(uriInfo.getQueryParameters());
+        if (responseParameters.isEmpty()) {
+            responseParameters.addAll(typicalResponseParameters);
+        }
+        boolean prettyPrint = ApiParameterHelper.prettyPrint(uriInfo.getQueryParameters());
+
+        GroupAccountSummaryCollectionData clientAccount = this.groupReadPlatformService.retrieveGroupAccountDetails(groupId);
+
+        return this.apiJsonSerializerService.serializeGroupAccountSummaryCollectionDataToJson(prettyPrint, responseParameters, clientAccount);
     }
 }

--- a/mifosng-provider/src/main/java/org/mifosng/platform/api/commands/LoanApplicationCommand.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/api/commands/LoanApplicationCommand.java
@@ -12,6 +12,7 @@ public class LoanApplicationCommand {
 	
 	private final Long loanId;
 	private final Long clientId;
+	private final Long groupId;
 	private final Long productId;
 	private final String externalId;
 	
@@ -48,7 +49,7 @@ public class LoanApplicationCommand {
 	public LoanApplicationCommand(
 			final Set<String> modifiedParameters,
 			final Long loanId,
-			final Long clientId, final Long productId, final String externalId, 
+			final Long clientId, final Long groupId, final Long productId, final String externalId,
 			final Long fundId, final Long transactionProcessingStrategyId,
 			final LocalDate submittedOnDate, final String submittedOnNote,
 			final LocalDate expectedDisbursementDate,
@@ -66,6 +67,7 @@ public class LoanApplicationCommand {
 		this.modifiedParameters = modifiedParameters;
 		this.loanId = loanId;
 		this.clientId = clientId;
+		this.groupId = groupId;
 		this.productId = productId;
 		this.externalId = externalId;
 		this.fundId = fundId;
@@ -110,6 +112,10 @@ public class LoanApplicationCommand {
 
 	public Long getClientId() {
 		return clientId;
+	}
+
+	public Long getGroupId() {
+		return groupId;
 	}
 
 	public Long getProductId() {

--- a/mifosng-provider/src/main/java/org/mifosng/platform/api/data/GroupAccountSummaryCollectionData.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/api/data/GroupAccountSummaryCollectionData.java
@@ -1,0 +1,73 @@
+package org.mifosng.platform.api.data;
+
+
+import java.util.List;
+
+public class GroupAccountSummaryCollectionData {
+
+	private final int anyLoanCount;
+	private final int pendingApprovalLoanCount;
+	private final List<GroupAccountSummaryData> pendingApprovalLoans;
+	private final int awaitingDisbursalLoanCount;
+	private final List<GroupAccountSummaryData> awaitingDisbursalLoans;
+	private final int activeLoanCount;
+	private final List<GroupAccountSummaryData> openLoans;
+	private final int closedLoanCount;
+	private final List<GroupAccountSummaryData> closedLoans;
+
+
+    public GroupAccountSummaryCollectionData(List<GroupAccountSummaryData> pendingApprovalLoans,
+                                             List<GroupAccountSummaryData> awaitingDisbursalLoans,
+                                             List<GroupAccountSummaryData> openLoans,
+                                             List<GroupAccountSummaryData> closedLoans) {
+        this.pendingApprovalLoans = pendingApprovalLoans;
+        this.pendingApprovalLoanCount = pendingApprovalLoans.size();
+
+        this.awaitingDisbursalLoans = awaitingDisbursalLoans;
+        this.awaitingDisbursalLoanCount = awaitingDisbursalLoans.size();
+
+        this.openLoans = openLoans;
+        this.activeLoanCount = openLoans.size();
+
+        this.closedLoans = closedLoans;
+        this.closedLoanCount = closedLoans.size();
+
+        this.anyLoanCount = pendingApprovalLoanCount + awaitingDisbursalLoanCount + activeLoanCount + closedLoanCount;
+    }
+
+    public int getAnyLoanCount() {
+		return anyLoanCount;
+	}
+
+	public int getPendingApprovalLoanCount() {
+		return pendingApprovalLoanCount;
+	}
+
+	public List<GroupAccountSummaryData> getPendingApprovalLoans() {
+		return pendingApprovalLoans;
+	}
+
+	public int getAwaitingDisbursalLoanCount() {
+		return awaitingDisbursalLoanCount;
+	}
+
+	public List<GroupAccountSummaryData> getAwaitingDisbursalLoans() {
+		return awaitingDisbursalLoans;
+	}
+
+	public int getActiveLoanCount() {
+		return activeLoanCount;
+	}
+
+	public List<GroupAccountSummaryData> getOpenLoans() {
+		return openLoans;
+	}
+
+	public int getClosedLoanCount() {
+		return closedLoanCount;
+	}
+
+	public List<GroupAccountSummaryData> getClosedLoans() {
+		return closedLoans;
+	}
+}

--- a/mifosng-provider/src/main/java/org/mifosng/platform/api/data/GroupAccountSummaryData.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/api/data/GroupAccountSummaryData.java
@@ -1,0 +1,44 @@
+package org.mifosng.platform.api.data;
+
+/**
+ * Immutable data object for group loan accounts.
+ */
+public class GroupAccountSummaryData {
+
+    private final Long id;
+    private final String externalId;
+    private final Long productId;
+    private final String productName;
+    private final Integer accountStatusId;
+
+    public GroupAccountSummaryData(Long id, String externalId,
+                                   Long productId,
+                                   String productName,
+                                   Integer accountStatusId) {
+        this.id = id;
+        this.externalId = externalId;
+        this.productId = productId;
+        this.productName = productName;
+        this.accountStatusId = accountStatusId;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public Long getProductId() {
+        return productId;
+    }
+
+    public String getProductName() {
+        return productName;
+    }
+
+    public Integer getAccountStatusId() {
+        return accountStatusId;
+    }
+}

--- a/mifosng-provider/src/main/java/org/mifosng/platform/api/data/GroupData.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/api/data/GroupData.java
@@ -42,7 +42,15 @@ public class GroupData {
         return name;
     }
 
-    public String getExternalId() {
+	public Long getOfficeId() {
+		return officeId;
+	}
+
+	public String getOfficeName() {
+		return officeName;
+	}
+
+	public String getExternalId() {
         return externalId;
     }
 

--- a/mifosng-provider/src/main/java/org/mifosng/platform/api/data/LoanAccountData.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/api/data/LoanAccountData.java
@@ -17,6 +17,8 @@ public class LoanAccountData {
 	private final String externalId;
 	private final Long clientId;
 	private final String clientName;
+	private final Long groupId;
+	private final String groupName;
 	private final Long loanProductId;
 	private final String loanProductName;
 	private final String loanProductDescription;
@@ -134,6 +136,8 @@ public class LoanAccountData {
 		this.externalId = basicDetails.getExternalId();
 		this.clientId = basicDetails.getClientId();
 		this.clientName = basicDetails.getClientName();
+		this.groupId = basicDetails.getGroupId();
+		this.groupName = basicDetails.getGroupName();
 		this.loanProductId = basicDetails.getLoanProductId();
 		this.loanProductName = basicDetails.getLoanProductName();
 		this.loanProductDescription = basicDetails.getLoanProductDescription();

--- a/mifosng-provider/src/main/java/org/mifosng/platform/api/data/LoanBasicDetailsData.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/api/data/LoanBasicDetailsData.java
@@ -19,6 +19,9 @@ public class LoanBasicDetailsData {
 	private final Long clientId;
 	private final Long clientOfficeId;
 	private final String clientName;
+	private final Long groupId;
+	private final Long groupOfficeId;
+	private final String groupName;
 	private final Long loanProductId;
 	private final String loanProductName;
 	private final String loanProductDescription;
@@ -57,11 +60,17 @@ public class LoanBasicDetailsData {
 	private final BigDecimal totalDisbursementCharges;
 	private final Collection<LoanChargeData> charges;
 	
-	public static LoanBasicDetailsData populateForNewLoanCreation(final Long clientId, final String clientName, final LocalDate expectedDisbursementDate,
-																	final Long clientOfficeId) {
-		return new LoanBasicDetailsData(clientId, clientName, expectedDisbursementDate, clientOfficeId);
+	public static LoanBasicDetailsData populateForNewIndividualClientLoanCreation(final Long clientId, final String clientName, final LocalDate expectedDisbursementDate,
+																				  final Long clientOfficeId) {
+		return new LoanBasicDetailsData(clientId, clientName, clientOfficeId, null, null, null, expectedDisbursementDate);
 	}
-	
+
+	public static LoanBasicDetailsData populateForNewGroupLoanCreation(final Long groupId, final String groupName,
+																	   final LocalDate expectedDisbursementDate,
+																	   final Long groupOfficeId){
+		return new LoanBasicDetailsData(null, null, null, groupId, groupName, groupOfficeId, expectedDisbursementDate);
+	}
+
 	public static LoanBasicDetailsData populateForNewLoanCreation(final LoanBasicDetailsData loanAccount, final LoanProductData product) {
 		
 		final Integer termFrequency = product.getNumberOfRepayments() * product.getRepaymentEvery();
@@ -75,7 +84,8 @@ public class LoanBasicDetailsData {
 
 		return new LoanBasicDetailsData(
 				loanAccount.clientId, loanAccount.clientName, loanAccount.clientOfficeId,
-				product.getId(), product.getName(), product.getDescription(), product.getFundId(), product.getFundName(), 
+				loanAccount.groupId, loanAccount.groupName, loanAccount.groupOfficeId,
+				product.getId(), product.getName(), product.getDescription(), product.getFundId(), product.getFundName(),
 				product.getCurrency(), product.getPrincipal(), product.getInArrearsTolerance(),
 				termFrequency, termPeriodFrequencyType, product.getNumberOfRepayments(), product.getRepaymentEvery(), product.getRepaymentFrequencyType(),
 				product.getTransactionProcessingStrategyId(), product.getAmortizationType(), 
@@ -85,6 +95,7 @@ public class LoanBasicDetailsData {
 	
 	private LoanBasicDetailsData(
 			final Long clientId, final String clientName, final Long clientOfficeId,
+			final Long groupId, final String groupName, final Long groupOfficeId,
 			final Long productId, final String productName, final String productDescription, final Long fundId, final String fundName, 
 			final CurrencyData currency,  final BigDecimal principal, final BigDecimal inArrearsTolerance,
 			final Integer termFrequency,
@@ -104,6 +115,9 @@ public class LoanBasicDetailsData {
 		this.clientId = clientId;
 		this.clientName = clientName;
 		this.clientOfficeId = clientOfficeId;
+		this.groupId = groupId;
+		this.groupName = groupName;
+		this.groupOfficeId = groupOfficeId;
 		this.loanProductId =  productId;
 		this.loanProductName = productName;
 		this.loanProductDescription= productDescription;
@@ -151,12 +165,17 @@ public class LoanBasicDetailsData {
 		this.totalDisbursementCharges = BigDecimal.ZERO;
 	}
 	
-	private LoanBasicDetailsData(final Long clientId, final String clientName, final LocalDate expectedDisbursementDate, final Long clientOfficeId) {
+	private LoanBasicDetailsData(final Long clientId, final String clientName, final Long clientOfficeId,
+								 final Long groupId, final String groupName, final Long groupOfficeId,
+								 final LocalDate expectedDisbursementDate) {
 		this.id = null;
 		this.externalId = null;
 		this.clientId = clientId;
 		this.clientName = clientName;
 		this.clientOfficeId = clientOfficeId;
+		this.groupId = groupId;
+		this.groupName = groupName;
+		this.groupOfficeId = groupOfficeId;
 		this.loanProductId =  null;
 		this.loanProductName = null;
 		this.loanProductDescription= null;
@@ -201,7 +220,11 @@ public class LoanBasicDetailsData {
 			final Long id, 
 			final String externalId,
 			final Long clientId, final String clientName,
-			final Long clientOfficeId, final Long loanProductId,
+			final Long clientOfficeId,
+			final Long groupId,
+			final String groupName,
+			final Long groupOfficeId,
+			final Long loanProductId,
 			final String loanProductName,
 			final String loanProductDescription,
 			final Long fundId, String fundName,
@@ -238,6 +261,9 @@ public class LoanBasicDetailsData {
 		this.clientId = clientId;
 		this.clientName = clientName;
 		this.clientOfficeId = clientOfficeId;
+		this.groupId = groupId;
+		this.groupName = groupName;
+		this.groupOfficeId = groupOfficeId;
 		this.loanProductId = loanProductId;
 		this.loanProductName = loanProductName;
 		this.loanProductDescription = loanProductDescription;
@@ -381,6 +407,18 @@ public class LoanBasicDetailsData {
 	
 	public Long getClientOfficeId() {
 		return clientOfficeId;
+	}
+
+	public Long getGroupId() {
+		return groupId;
+	}
+
+	public Long getGroupOfficeId() {
+		return groupOfficeId;
+	}
+
+	public String getGroupName() {
+		return groupName;
 	}
 
 	public Long getFundId() {

--- a/mifosng-provider/src/main/java/org/mifosng/platform/api/infrastructure/ApiDataConversionServiceImpl.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/api/infrastructure/ApiDataConversionServiceImpl.java
@@ -444,7 +444,7 @@ public class ApiDataConversionServiceImpl implements ApiDataConversionService {
 	    Map<String, Object> requestMap = gsonConverter.fromJson(json, typeOfMap);
 	    
 	    Set<String> supportedParams = new HashSet<String>(
-    		Arrays.asList("clientId", "productId", "externalId", "fundId", "transactionProcessingStrategyId",
+    		Arrays.asList("clientId", "groupId", "productId", "externalId", "fundId", "transactionProcessingStrategyId",
     				"principal", "inArrearsTolerance", "interestRatePerPeriod", "repaymentEvery", "numberOfRepayments", 
     				"loanTermFrequency", "loanTermFrequencyType", "charges",
     				"repaymentFrequencyType", "interestRateFrequencyType", "amortizationType", "interestType", "interestCalculationPeriodType",
@@ -461,6 +461,7 @@ public class ApiDataConversionServiceImpl implements ApiDataConversionService {
 	    JsonParserHelper helper = new JsonParserHelper();
 	    
 	    final Long clientId = helper.extractLongNamed("clientId", element, modifiedParameters);
+		final Long groupId = helper.extractLongNamed("groupId", element, modifiedParameters);
 	    final Long productId = helper.extractLongNamed("productId", element, modifiedParameters);
 	    final Long fundId = helper.extractLongNamed("fundId", element, modifiedParameters);
 	    final Long loanOfficerId = helper.extractLongNamed("loanOfficerId", element, modifiedParameters);
@@ -514,7 +515,7 @@ public class ApiDataConversionServiceImpl implements ApiDataConversionService {
         }
 
 		return new LoanApplicationCommand(modifiedParameters,
-				resourceIdentifier, clientId, productId, externalId, fundId, transactionProcessingStrategyId,
+				resourceIdentifier, clientId, groupId, productId, externalId, fundId, transactionProcessingStrategyId,
 				submittedOnDate, submittedOnNote, 
 	    		expectedDisbursementDate, repaymentsStartingFromDate, interestChargedFromDate, 
 	    		principal, interestRatePerPeriod, interestRateFrequencyType, interestType, interestCalculationPeriodType, 

--- a/mifosng-provider/src/main/java/org/mifosng/platform/api/infrastructure/ApiJsonSerializerService.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/api/infrastructure/ApiJsonSerializerService.java
@@ -17,6 +17,7 @@ import org.mifosng.platform.api.data.DepositProductData;
 import org.mifosng.platform.api.data.EntityIdentifier;
 import org.mifosng.platform.api.data.FundData;
 import org.mifosng.platform.api.data.GenericResultsetData;
+import org.mifosng.platform.api.data.GroupAccountSummaryCollectionData;
 import org.mifosng.platform.api.data.GroupData;
 import org.mifosng.platform.api.data.LoanAccountData;
 import org.mifosng.platform.api.data.LoanChargeData;
@@ -85,6 +86,8 @@ public interface ApiJsonSerializerService {
 	String serializeClientDataToJson(boolean prettyPrint, Set<String> responseParameters, ClientData clientData);
 
 	String serializeClientAccountSummaryCollectionDataToJson(boolean prettyPrint, Set<String> responseParameters, ClientAccountSummaryCollectionData clientAccount);
+
+    String serializeGroupAccountSummaryCollectionDataToJson(boolean prettyPrint, Set<String> responseParameters, GroupAccountSummaryCollectionData groupAccount);
 
 	String serializeGroupDataToJson(boolean prettyPrint, Set<String> responseParameters, Collection<GroupData> groups);
 

--- a/mifosng-provider/src/main/java/org/mifosng/platform/api/infrastructure/GoogleGsonApiJsonSerializerService.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/api/infrastructure/GoogleGsonApiJsonSerializerService.java
@@ -19,6 +19,7 @@ import org.mifosng.platform.api.data.DepositProductData;
 import org.mifosng.platform.api.data.EntityIdentifier;
 import org.mifosng.platform.api.data.FundData;
 import org.mifosng.platform.api.data.GenericResultsetData;
+import org.mifosng.platform.api.data.GroupAccountSummaryCollectionData;
 import org.mifosng.platform.api.data.GroupData;
 import org.mifosng.platform.api.data.LoanAccountData;
 import org.mifosng.platform.api.data.LoanChargeData;
@@ -131,6 +132,12 @@ public class GoogleGsonApiJsonSerializerService implements ApiJsonSerializerServ
 					"rejectedDepositAccountsCount","rejectedDepositAccounts",
 					"preclosedDepositAccountsCount","preclosedDepositAccounts"));
 
+    private static final Set<String> GROUP_ACCOUNTS_DATA_PARAMETERS = new HashSet<String>(
+            Arrays.asList("pendingApprovalLoans", "awaitingDisbursalLoans",
+                    "openLoans", "closedLoans", "anyLoanCount",
+                    "pendingApprovalLoanCount", "awaitingDisbursalLoanCount",
+                    "activeLoanCount", "closedLoanCount"));
+
 	private static final Set<String> GROUP_DATA_PARAMETERS = new HashSet<String>(
 			Arrays.asList("id", "officeId", "name", "externalId", "clientMembers",
 					"allowedClients", "allowedOffices"));
@@ -145,7 +152,7 @@ public class GoogleGsonApiJsonSerializerService implements ApiJsonSerializerServ
 			Arrays.asList("periods", "cumulativePrincipalDisbursed"));
 	
 	private static final Set<String> LOAN_DATA_PARAMETERS = new HashSet<String>(
-			Arrays.asList("id", "externalId", "clientId", "clientName", "fundId", "fundName",
+			Arrays.asList("id", "externalId", "clientId","groupId", "clientName", "groupName", "fundId", "fundName",
 					"loanProductId", "loanProductName", "loanProductDescription", 
 					"currency", "principal",
 					"inArrearsTolerance", "numberOfRepayments",
@@ -467,6 +474,17 @@ public class GoogleGsonApiJsonSerializerService implements ApiJsonSerializerServ
 						responseParameters);
 		return helper.serializedJsonFrom(gsonDeserializer, clientAccount);
 	}
+
+    @Override
+    public String serializeGroupAccountSummaryCollectionDataToJson(
+            final boolean prettyPrint, final Set<String> responseParameters,
+            final GroupAccountSummaryCollectionData groupAccount) {
+        final Gson gsonDeserializer = helper
+                .createGsonBuilderWithParameterExclusionSerializationStrategy(
+                        GROUP_ACCOUNTS_DATA_PARAMETERS, prettyPrint,
+                        responseParameters);
+        return helper.serializedJsonFrom(gsonDeserializer, groupAccount);
+    }
 
 	@Override
 	public String serializeGroupDataToJson(final boolean prettyPrint,

--- a/mifosng-provider/src/main/java/org/mifosng/platform/group/service/GroupReadPlatformService.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/group/service/GroupReadPlatformService.java
@@ -2,6 +2,7 @@ package org.mifosng.platform.group.service;
 
 import java.util.Collection;
 
+import org.mifosng.platform.api.data.GroupAccountSummaryCollectionData;
 import org.mifosng.platform.api.data.ClientLookup;
 import org.mifosng.platform.api.data.GroupData;
 
@@ -14,4 +15,6 @@ public interface GroupReadPlatformService {
     GroupData retrieveNewGroupDetails();
 
     Collection<ClientLookup> retrieveClientMembers(Long groupId);
+
+    GroupAccountSummaryCollectionData retrieveGroupAccountDetails(Long groupId);
 }

--- a/mifosng-provider/src/main/java/org/mifosng/platform/loan/service/LoanApplicationCommandValidator.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/loan/service/LoanApplicationCommandValidator.java
@@ -26,7 +26,15 @@ public class LoanApplicationCommandValidator {
 //					"The parameter loanSchedule cannot be empty.", "loanSchedule");
 //			dataValidationErrors.add(error);
 //		}
-		
+		DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors).resource("loan");
+
+		if (command.getGroupId() != null){
+			baseDataValidator.reset().parameter("clientId").value(command.getClientId()).mustBeBlankWhenParameterProvided("groupId", command.getGroupId()).longGreaterThanZero();
+		}
+		if (command.getClientId() != null){
+			baseDataValidator.reset().parameter("groupId").value(command.getGroupId()).mustBeBlankWhenParameterProvided("clientId", command.getClientId()).longGreaterThanZero();
+		}
+
 		if (command.getSubmittedOnDate() == null) {
 			ApiParameterError error = ApiParameterError.parameterError("validation.msg.loan.submitted.on.date.cannot.be.blank", 
 					"The parameter submittedOnDate cannot be empty.", "submittedOnDate");
@@ -41,7 +49,6 @@ public class LoanApplicationCommandValidator {
 		}
 		
 		if (command.getTransactionProcessingStrategyId() == null) {
-			DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors).resource("loan");
 			baseDataValidator.reset().parameter("transactionProcessingStrategyId").value(command.getTransactionProcessingStrategyId()).notNull().inMinMaxRange(2, 2);
 		}
 		

--- a/mifosng-provider/src/main/java/org/mifosng/platform/loan/service/LoanReadPlatformService.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/loan/service/LoanReadPlatformService.java
@@ -25,6 +25,8 @@ public interface LoanReadPlatformService {
 
 	LoanBasicDetailsData retrieveClientAndProductDetails(Long clientId, Long productId);
 
+    LoanBasicDetailsData retrieveGroupAndProductDetails(Long groupId, Long productId);
+
 	LoanTransactionData retrieveNewLoanRepaymentDetails(Long loanId);
 
 	LoanTransactionData retrieveNewLoanWaiverDetails(Long loanId);


### PR DESCRIPTION
Support for Solidarity Group Loan.

Makes use of current loan infrastructure.

Currently, there is no validation at schema level for m_loan relation with m_client/m_group (either client_id or group_id not null). Could this be handled later?

Next, group client members office validation will be added.
