### PR TITLE
support for MIFOSX-73: Loan Officer reassignment History.

### DIFF
--- a/mifosng-db/patches/patch-0013-loan_officer_reassignment_history.sql
+++ b/mifosng-db/patches/patch-0013-loan_officer_reassignment_history.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `m_loan_officer_assignment_history` (
+`id` bigint(20) NOT NULL AUTO_INCREMENT,
+`loan_id` bigint(20) NOT NULL ,
+`loan_officer_id` bigint(20) DEFAULT NULL,
+`start_date` date NOT NULL,
+`end_date` date DEFAULT NULL,
+`createdby_id` bigint(20) DEFAULT NULL,
+`created_date` datetime DEFAULT NULL,
+`lastmodified_date` datetime DEFAULT NULL,
+`lastmodifiedby_id` bigint(20) DEFAULT NULL,
+PRIMARY KEY (`id`),
+CONSTRAINT `fk_m_loan_officer_assignment_history_0001` FOREIGN KEY (`loan_id`) REFERENCES `m_loan` (`id`),
+CONSTRAINT `fk_m_loan_officer_assignment_history_0002` FOREIGN KEY (`loan_officer_id`) REFERENCES `m_staff` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/mifosng-provider/src/main/java/org/mifosng/platform/api/StaffApiResource.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/api/StaffApiResource.java
@@ -18,6 +18,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import org.apache.commons.lang.StringUtils;
+import org.joda.time.LocalDate;
 import org.mifosng.platform.api.commands.BulkLoanReassignmentCommand;
 import org.mifosng.platform.api.commands.StaffCommand;
 import org.mifosng.platform.api.data.EntityIdentifier;
@@ -179,8 +180,8 @@ public class StaffApiResource {
             staffAccountSummaryCollectionData = this.readPlatformService.retrieveLoanOfficerAccountSummary(loanOfficerId);
         }
 
-        final LoanReassignmentData loanReassignmentData = new LoanReassignmentData(officeId, loanOfficerId, offices,
-                loanOfficers, staffAccountSummaryCollectionData);
+        final LoanReassignmentData loanReassignmentData = new LoanReassignmentData(officeId, loanOfficerId,
+                new LocalDate(), offices, loanOfficers, staffAccountSummaryCollectionData);
 
         return this.apiJsonSerializerService.serializeLoanReassignmentDataToJson(prettyPrint, responseParameters, loanReassignmentData);
     }

--- a/mifosng-provider/src/main/java/org/mifosng/platform/api/commands/BulkLoanReassignmentCommand.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/api/commands/BulkLoanReassignmentCommand.java
@@ -1,5 +1,7 @@
 package org.mifosng.platform.api.commands;
 
+import org.joda.time.LocalDate;
+
 /**
  * Immutable data object for reassigning loan officers on loans in bulk.
  */
@@ -7,13 +9,15 @@ public class BulkLoanReassignmentCommand {
 
 	private final Long fromLoanOfficerId;
 	private final Long toLoanOfficerId;
+    private final LocalDate assignmentDate;
 
 	private final String[] loans;
 
 	public BulkLoanReassignmentCommand(Long fromLoanOfficerId,
-			Long toLoanOfficerId, String[] loans) {
+			Long toLoanOfficerId, LocalDate assignmentDate, String[] loans) {
 		this.fromLoanOfficerId = fromLoanOfficerId;
 		this.toLoanOfficerId = toLoanOfficerId;
+        this.assignmentDate = assignmentDate;
 		this.loans = loans;
 	}
 
@@ -25,7 +29,11 @@ public class BulkLoanReassignmentCommand {
 		return toLoanOfficerId;
 	}
 
-	public String[] getLoans() {
+    public LocalDate getAssignmentDate() {
+        return assignmentDate;
+    }
+
+    public String[] getLoans() {
 		return loans;
 	}
 }

--- a/mifosng-provider/src/main/java/org/mifosng/platform/api/data/LoanReassignmentData.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/api/data/LoanReassignmentData.java
@@ -1,5 +1,7 @@
 package org.mifosng.platform.api.data;
 
+import org.joda.time.LocalDate;
+
 import java.util.Collection;
 
 /**
@@ -11,6 +13,8 @@ public class LoanReassignmentData {
 	private final Long officeId;
     @SuppressWarnings("unused")
     private final Long fromLoanOfficerId;
+    @SuppressWarnings("unused")
+    private final LocalDate assignmentDate;
 
     //template
     @SuppressWarnings("unused")
@@ -23,11 +27,13 @@ public class LoanReassignmentData {
     public LoanReassignmentData(
     		final Long officeId, 
     		final Long fromLoanOfficerId,
+            final LocalDate assignmentDate,
             final Collection<OfficeLookup> officeOptions, 
             final Collection<StaffData> loanOfficerOptions,
             final StaffAccountSummaryCollectionData accountSummaryCollection) {
         this.officeId = officeId;
         this.fromLoanOfficerId = fromLoanOfficerId;
+        this.assignmentDate = assignmentDate;
         this.officeOptions = officeOptions;
         this.loanOfficerOptions = loanOfficerOptions;
         this.accountSummaryCollection = accountSummaryCollection;

--- a/mifosng-provider/src/main/java/org/mifosng/platform/api/infrastructure/GoogleGsonPortfolioApiJsonSerializerService.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/api/infrastructure/GoogleGsonPortfolioApiJsonSerializerService.java
@@ -194,7 +194,8 @@ public class GoogleGsonPortfolioApiJsonSerializerService implements PortfolioApi
 			Arrays.asList("id", "type", "date", "currency", "amount"));
 
     private static final Set<String> LOAN_REASSIGNMENT_DATA_PARAMETERS = new HashSet<String>(
-            Arrays.asList("officeId", "fromLoanOfficerId", "officeOptions", "loanOfficerOptions", "accountSummaryCollection")
+            Arrays.asList("officeId", "fromLoanOfficerId", "assignmentDate",
+                    "officeOptions", "loanOfficerOptions", "accountSummaryCollection")
     );
 
 	private static final Set<String> CHARGES_DATA_PARAMETERS = new HashSet<String>(

--- a/mifosng-provider/src/main/java/org/mifosng/platform/api/infrastructure/PortfolioApiDataConversionServiceImpl.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/api/infrastructure/PortfolioApiDataConversionServiceImpl.java
@@ -167,7 +167,7 @@ public class PortfolioApiDataConversionServiceImpl implements PortfolioApiDataCo
         Map<String, String> requestMap = gsonConverter.fromJson(json, typeOfMap);
 
         Set<String> supportedParams = new HashSet<String>(
-                Arrays.asList("fromLoanOfficerId", "toLoanOfficerId","loans")
+                Arrays.asList("fromLoanOfficerId", "toLoanOfficerId", "assignmentDate", "locale", "dateFormat", "loans")
         );
 
         checkForUnsupportedParameters(requestMap, supportedParams);
@@ -176,6 +176,7 @@ public class PortfolioApiDataConversionServiceImpl implements PortfolioApiDataCo
 
         Long fromLoanOfficerId = extractLongParameter("fromLoanOfficerId", requestMap, modifiedParameters);
         Long toLoanOfficerId = extractLongParameter("toLoanOfficerId", requestMap, modifiedParameters);
+        LocalDate assignmentDate = extractLocalDateParameter("assignmentDate", requestMap, modifiedParameters);
 
         // check array
         JsonParser parser = new JsonParser();
@@ -195,7 +196,7 @@ public class PortfolioApiDataConversionServiceImpl implements PortfolioApiDataCo
         }
         //
 
-        return new BulkLoanReassignmentCommand(fromLoanOfficerId, toLoanOfficerId, loans);
+        return new BulkLoanReassignmentCommand(fromLoanOfficerId, toLoanOfficerId, assignmentDate, loans);
 	}
 
 	@Override
@@ -365,7 +366,7 @@ public class PortfolioApiDataConversionServiceImpl implements PortfolioApiDataCo
 	    checkForUnsupportedParameters(requestMap, supportedParams);
 	    
 	    Set<String> modifiedParameters = new HashSet<String>();
-	   
+
 	    String externalId = extractStringParameter("externalId", requestMap, modifiedParameters);
 	    Long officeId = extractLongParameter("officeId", requestMap, modifiedParameters);
 	    LocalDate joiningDate = extractLocalDateParameter("joiningDate", requestMap, modifiedParameters);

--- a/mifosng-provider/src/main/java/org/mifosng/platform/exceptions/LoanOfficerAssignmentException.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/exceptions/LoanOfficerAssignmentException.java
@@ -1,11 +1,18 @@
 package org.mifosng.platform.exceptions;
 
 
+import org.joda.time.LocalDate;
+
 public class LoanOfficerAssignmentException extends
         AbstractPlatformDomainRuleException {
 
-    public LoanOfficerAssignmentException(final Long loanId, final Long loanOfficerId) {
+    public LoanOfficerAssignmentException(final Long loanId, final Long fromLoanOfficerId) {
         super("error.msg.loan.not.assigned.to.loan.officer", "Loan with identifier " + loanId +
-              " is not assigned to Loan Officer with identifier " + loanOfficerId + ".", loanId);
+              " is not assigned to Loan Officer with identifier " + fromLoanOfficerId + ".", loanId);
+    }
+
+    public LoanOfficerAssignmentException(final Long loanId, final LocalDate date){
+        super("error.msg.loan.assignment.date.is.before.last.assignment.date", "Loan with identifier " + loanId +
+              " was already assigned before date " + date.toString());
     }
 }

--- a/mifosng-provider/src/main/java/org/mifosng/platform/loan/domain/Loan.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/loan/domain/Loan.java
@@ -434,7 +434,15 @@ public class Loan extends AbstractAuditableCustom<AppUser, Long> {
 		return this.loanProduct;
 	}
 
-	public LoanProductRelatedDetail repaymentScheduleDetail() {
+    public Staff getLoanofficer() {
+        return loanofficer;
+    }
+
+    public void setLoanofficer(Staff loanofficer) {
+        this.loanofficer = loanofficer;
+    }
+
+    public LoanProductRelatedDetail repaymentScheduleDetail() {
 		return this.loanRepaymentScheduleDetail;
 	}
 	
@@ -1537,6 +1545,13 @@ public class Loan extends AbstractAuditableCustom<AppUser, Long> {
 		
 		return matchesCurrentLoanOfficer;
 	}
+
+    public boolean hasLoanOfficer(){
+
+        boolean hasLoanOfficerAssigned = this.loanofficer != null;
+
+        return hasLoanOfficerAssigned;
+    }
 
 	public LocalDate getInterestChargedFromDate() {
 		LocalDate interestChargedFrom = null;

--- a/mifosng-provider/src/main/java/org/mifosng/platform/loan/domain/LoanOfficerAssignmentHistory.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/loan/domain/LoanOfficerAssignmentHistory.java
@@ -1,0 +1,85 @@
+package org.mifosng.platform.loan.domain;
+
+
+import org.joda.time.LocalDate;
+import org.mifosng.platform.infrastructure.AbstractAuditableCustom;
+import org.mifosng.platform.staff.domain.Staff;
+import org.mifosng.platform.user.domain.AppUser;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import java.util.Date;
+
+@Entity
+@Table(name = "m_loan_officer_assignment_history")
+public class LoanOfficerAssignmentHistory extends AbstractAuditableCustom<AppUser, Long> {
+
+    @SuppressWarnings("unused")
+    @ManyToOne
+    @JoinColumn(name = "loan_id", nullable = false)
+    private Loan loan;
+
+    @SuppressWarnings("unused")
+    @ManyToOne
+    @JoinColumn(name = "loan_officer_id", nullable = true)
+    private Staff loanOfficer;
+
+    @Temporal(TemporalType.DATE)
+    @Column(name = "start_date")
+    private Date startDate;
+
+    @SuppressWarnings("unused")
+    @Temporal(TemporalType.DATE)
+    @Column(name = "end_date")
+    private Date endDate;
+
+    public static LoanOfficerAssignmentHistory createNew(Loan loan, Staff loanOfficer,
+                                                         LocalDate startDate){
+        return new LoanOfficerAssignmentHistory(loan, loanOfficer, startDate.toDate(), null);
+    }
+
+    @SuppressWarnings("unused")
+    protected LoanOfficerAssignmentHistory() {
+        this.loan = null;
+        this.loanOfficer = null;
+        this.startDate = null;
+        this.endDate = null;
+    }
+
+    private LoanOfficerAssignmentHistory(Loan loan, Staff loanOfficer,
+                                        Date startDate, Date endDate) {
+        this.loan = loan;
+        this.loanOfficer = loanOfficer;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public Loan getLoan() {
+        return loan;
+    }
+
+    public LocalDate getStartDate() {
+        return new LocalDate(startDate);
+    }
+
+    public void updateLoanOfficer(Staff loanOfficer) {
+        this.loanOfficer = loanOfficer;
+    }
+
+    public void updateStartDate(LocalDate startDate){
+        this.startDate = startDate.toDate();
+    }
+
+    public void updateEndDate(LocalDate endDate){
+        this.endDate = endDate.toDate();
+    }
+
+    public boolean wasAlreadyAssignedToday(){
+        return this.getLastModifiedDate().toLocalDate().isEqual(new LocalDate());
+    }
+}

--- a/mifosng-provider/src/main/java/org/mifosng/platform/loan/domain/LoanOfficerAssignmentHistoryRepository.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/loan/domain/LoanOfficerAssignmentHistoryRepository.java
@@ -1,0 +1,13 @@
+package org.mifosng.platform.loan.domain;
+
+
+import org.mifosng.platform.staff.domain.Staff;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface LoanOfficerAssignmentHistoryRepository extends JpaRepository<LoanOfficerAssignmentHistory, Long>,
+        JpaSpecificationExecutor<LoanOfficerAssignmentHistory> {
+
+    LoanOfficerAssignmentHistory findByLoanAndLoanOfficerAndEndDateIsNull(Loan loan, Staff loanOfficer);
+
+}

--- a/mifosng-provider/src/main/java/org/mifosng/platform/loan/service/LoanOfficerAssignmentHistoryWritePlatformService.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/loan/service/LoanOfficerAssignmentHistoryWritePlatformService.java
@@ -1,0 +1,18 @@
+package org.mifosng.platform.loan.service;
+
+
+import org.joda.time.LocalDate;
+import org.mifosng.platform.loan.domain.Loan;
+import org.mifosng.platform.staff.domain.Staff;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+public interface LoanOfficerAssignmentHistoryWritePlatformService {
+
+    @PreAuthorize(value = "hasRole('ORGANISATION_ADMINISTRATION_SUPER_USER_ROLE')")
+    public void trackLoanOfficerAssignmentHistory(final Loan loan, final Staff fromLoanOfficer,
+                                                  final Staff toLoanOfficer, final LocalDate startDate);
+
+    @PreAuthorize(value = "hasRole('ORGANISATION_ADMINISTRATION_SUPER_USER_ROLE')")
+    public void untrackNewLoanOfficerAssignmentHistory(final Loan loan);
+
+}

--- a/mifosng-provider/src/main/java/org/mifosng/platform/loan/service/LoanOfficerAssignmentHistoryWritePlatformServiceJpaRepositoryImpl.java
+++ b/mifosng-provider/src/main/java/org/mifosng/platform/loan/service/LoanOfficerAssignmentHistoryWritePlatformServiceJpaRepositoryImpl.java
@@ -1,0 +1,71 @@
+package org.mifosng.platform.loan.service;
+
+import org.joda.time.LocalDate;
+import org.mifosng.platform.exceptions.LoanOfficerAssignmentException;
+import org.mifosng.platform.loan.domain.Loan;
+import org.mifosng.platform.loan.domain.LoanOfficerAssignmentHistory;
+import org.mifosng.platform.loan.domain.LoanOfficerAssignmentHistoryRepository;
+import org.mifosng.platform.staff.domain.Staff;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class LoanOfficerAssignmentHistoryWritePlatformServiceJpaRepositoryImpl implements LoanOfficerAssignmentHistoryWritePlatformService {
+
+    private final LoanOfficerAssignmentHistoryRepository loanOfficerAssignmentHistoryRepository;
+
+    @Autowired
+    public LoanOfficerAssignmentHistoryWritePlatformServiceJpaRepositoryImpl(
+            final LoanOfficerAssignmentHistoryRepository loanOfficerAssignmentHistoryRepository) {
+        this.loanOfficerAssignmentHistoryRepository = loanOfficerAssignmentHistoryRepository;
+    }
+
+    @Transactional
+    @Override
+    public void trackLoanOfficerAssignmentHistory(final Loan loan, final Staff fromLoanOfficer,
+                                                  final Staff toLoanOfficer, final LocalDate startDate) {
+        boolean createNewLoanOfficerAssignmentHistoryRecord = true;
+
+        LoanOfficerAssignmentHistory prevLoanOfficerAssignmentHistory = this.loanOfficerAssignmentHistoryRepository.
+                findByLoanAndLoanOfficerAndEndDateIsNull(loan, fromLoanOfficer);
+
+        if (prevLoanOfficerAssignmentHistory != null){
+
+            if (prevLoanOfficerAssignmentHistory.wasAlreadyAssignedToday()){
+                prevLoanOfficerAssignmentHistory.updateStartDate(startDate);
+                prevLoanOfficerAssignmentHistory.updateLoanOfficer(toLoanOfficer);
+                createNewLoanOfficerAssignmentHistoryRecord = false;
+            } else {
+                validateAssignmentStartDate(prevLoanOfficerAssignmentHistory, startDate);
+                prevLoanOfficerAssignmentHistory.updateEndDate(startDate);
+            }
+
+            this.loanOfficerAssignmentHistoryRepository.save(prevLoanOfficerAssignmentHistory);
+        }
+
+        if (createNewLoanOfficerAssignmentHistoryRecord && toLoanOfficer != null){
+            LoanOfficerAssignmentHistory newLoanOfficerAssignmentHistory = LoanOfficerAssignmentHistory.
+                    createNew(loan, toLoanOfficer, startDate);
+            this.loanOfficerAssignmentHistoryRepository.save(newLoanOfficerAssignmentHistory);
+        }
+    }
+
+    @Transactional
+    @Override
+    public void untrackNewLoanOfficerAssignmentHistory(final Loan loan) {
+        if (loan.hasLoanOfficer()){
+            LoanOfficerAssignmentHistory loanOfficerAssignmentHistory = this.loanOfficerAssignmentHistoryRepository.
+                    findByLoanAndLoanOfficerAndEndDateIsNull(loan, loan.getLoanofficer());
+            if (loanOfficerAssignmentHistory != null){
+                this.loanOfficerAssignmentHistoryRepository.delete(loanOfficerAssignmentHistory);
+            }
+        }
+    }
+
+    private void validateAssignmentStartDate(LoanOfficerAssignmentHistory loanOfficerAssignmentHistory, LocalDate startDate){
+        if (startDate.isBefore(loanOfficerAssignmentHistory.getStartDate())){
+            throw new LoanOfficerAssignmentException(loanOfficerAssignmentHistory.getLoan().getId(), startDate);
+        }
+    }
+}


### PR DESCRIPTION
Added support for tracking loan history assignment history.
I added support for uses cases mentioned in https://mifosforge.jira.com/browse/MIFOSX-73 description.
(also fixed missed validation pointed in comment for https://github.com/keithwoodlock/mifosx/pull/77)

Next thing to do is add restriction for changing loan_officer_id to only loan officer reassignment API calls (Not by modify loan API).

Please let me know if anything is missing or if you have any additional thoughts on this.
Thanks in advance.
