### PR TITLE
Add Interest posting functionality for fd

### DIFF
--- a/mifosng-db/patches/patch-05-saving-schedule-creation.sql
+++ b/mifosng-db/patches/patch-05-saving-schedule-creation.sql
@@ -1,3 +1,4 @@
+
 DROP TABLE IF EXISTS `m_saving_schedule`;
 CREATE TABLE `m_saving_schedule` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,

--- a/mifosng-db/patches/patch-08-additional_fields_for_m_deposit_account.sql
+++ b/mifosng-db/patches/patch-08-additional_fields_for_m_deposit_account.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `m_deposit_account`
+ ADD COLUMN `available_interest` decimal(19,6) DEFAULT '0.000000' AFTER `is_interest_withdrawable`,
+ ADD COLUMN `interest_posted_amount` decimal(19,6) DEFAULT '0.000000' AFTER `available_interest`,
+ ADD COLUMN `last_interest_posted_date` date DEFAULT NULL AFTER `interest_posted_amount`,
+ ADD COLUMN `next_interest_posting_date` date DEFAULT NULL AFTER `last_interest_posted_date`;

--- a/mifosng-db/patches/patch-09-extra_client_details-for_FD_Client.sql
+++ b/mifosng-db/patches/patch-09-extra_client_details-for_FD_Client.sql
@@ -1,0 +1,19 @@
+drop table if exists extra_client_details;
+
+CREATE TABLE `extra_client_details` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `client_id` bigint(20) NOT NULL,
+  `client_dob` date DEFAULT NULL,
+  `client_address` varchar(60) DEFAULT NULL,
+  `father_name` varchar(40) DEFAULT NULL,
+  `nominee` varchar(40) DEFAULT NULL,
+  `nominee_relationship` varchar(40) DEFAULT NULL,
+  `nominee_address` varchar(60) DEFAULT NULL,
+  `crime_no` varchar(40) DEFAULT NULL,
+  `police_station` varchar(40) DEFAULT NULL,
+  `other_notes` text,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `client_id` (`client_id`),
+  KEY `FK_extra_client_details_1` (`client_id`),
+  CONSTRAINT `FK_extra_client_details` FOREIGN KEY (`client_id`) REFERENCES `m_client` (`id`)
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8;

--- a/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/api/GoogleGsonPortfolioApiJsonSerializerService.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/api/GoogleGsonPortfolioApiJsonSerializerService.java
@@ -59,7 +59,8 @@ public class GoogleGsonPortfolioApiJsonSerializerService implements PortfolioApi
             "interestCompoundedEveryPeriodType", "renewalAllowed", "preClosureAllowed", "preClosureInterestRate", "withdrawnonDate",
             "rejectedonDate", "closedonDate", "transactions", "permissions", "isInterestWithdrawable", "interestPaid",
             "interestCompoundingAllowed", "availableInterestForWithdrawal", "availableWithdrawalAmount", "todaysDate",
-            "isLockinPeriodAllowed", "lockinPeriod", "lockinPeriodType"));
+            "isLockinPeriodAllowed", "lockinPeriod", "lockinPeriodType", "printFDdetailsLocation","availableInterest", "interestPostedAmount",
+            "lastInterestPostedDate", "nextInterestPostedDate","fatherName","address","imageKey"));
 
     private static final Set<String> DOCUMENT_DATA_PARAMETERS = new HashSet<String>(Arrays.asList("id", "parentEntityType",
             "parentEntityId", "name", "fileName", "type", "size", "description"));
@@ -101,7 +102,7 @@ public class GoogleGsonPortfolioApiJsonSerializerService implements PortfolioApi
     private static final Set<String> GUARANTOR_DATA_PARAMETERS = new HashSet<String>(Arrays.asList("externalGuarantor", "existingClientId",
             "firstname", "lastname", "addressLine1", "addressLine2", "city", "state", "zip", "country", "mobileNumber", "housePhoneNumber",
             "comment", "dob"));
-
+    
     private static final Set<String> SAVING_SCHEDULE_DATA_PARAMETERS = new HashSet<String>(Arrays.asList("periods", "cumulativeDepositDue"));
 
     private final GoogleGsonSerializerHelper helper;
@@ -296,4 +297,5 @@ public class GoogleGsonPortfolioApiJsonSerializerService implements PortfolioApi
                 prettyPrint, responseParameters);
         return helper.serializedJsonFrom(gsonDeserializer, savingScheduleData);
     }
+
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/api/PortfolioApiJsonSerializerService.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/api/PortfolioApiJsonSerializerService.java
@@ -77,4 +77,5 @@ public interface PortfolioApiJsonSerializerService {
 
     String serializeSavingScheduleDataToJson(boolean prettyPrint, Set<String> responseParameters, SavingScheduleData savingScheduleData);
 
+
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/data/EntityIdentifier.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/data/EntityIdentifier.java
@@ -1,5 +1,6 @@
 package org.mifosplatform.infrastructure.core.data;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -38,6 +39,7 @@ public class EntityIdentifier {
 
     public EntityIdentifier(final Long entityId) {
         this.entityId = entityId;
+        this.changes = new HashMap<String, Object>();
     }
 
     private EntityIdentifier(final Long entityId, final Long makerCheckerId, final Map<String, Object> changesOnly) {

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsaccount/api/SavingsAccountApiResource.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsaccount/api/SavingsAccountApiResource.java
@@ -143,37 +143,41 @@ public class SavingsAccountApiResource {
         if (responseParameters.isEmpty()) {
             responseParameters.addAll(typicalResponseParameters);
         }
-        boolean prettyPrint = ApiParameterHelper.prettyPrint(uriInfo.getQueryParameters());
+		
+		
+		boolean prettyPrint = ApiParameterHelper.prettyPrint(uriInfo.getQueryParameters());
+		
+		SavingAccountData account = this.savingAccountReadPlatformService.retrieveSavingsAccount(accountId);
+		
+		return this.apiJsonSerializerService.serializeSavingAccountsDataToJson(prettyPrint, responseParameters, account);
+	}
 
-        SavingAccountData account = this.savingAccountReadPlatformService.retrieveSavingsAccount(accountId);
+	@SuppressWarnings("unused")
+	@GET
+	@Path("template")
+	@Consumes({MediaType.APPLICATION_JSON})
+	@Produces({MediaType.APPLICATION_JSON})
+	public String retrieveNewDepositAccountDetails(
+			@QueryParam("clientId") final Long clientId,
+			@QueryParam("productId") final Long productId,
+			@Context final UriInfo uriInfo) {
 
-        return this.apiJsonSerializerService.serializeSavingAccountsDataToJson(prettyPrint, responseParameters, account);
-    }
-
-    @SuppressWarnings("unused")
-    @GET
-    @Path("template")
-    @Consumes({ MediaType.APPLICATION_JSON })
-    @Produces({ MediaType.APPLICATION_JSON })
-    public String retrieveNewDepositAccountDetails(@QueryParam("clientId") final Long clientId,
-            @QueryParam("productId") final Long productId, @Context final UriInfo uriInfo) {
-
-        context.authenticatedUser().validateHasReadPermission(entityType);
-
-        Set<String> responseParameters = ApiParameterHelper.extractFieldsForResponseIfProvided(uriInfo.getQueryParameters());
-        if (responseParameters.isEmpty()) {
-            responseParameters.addAll(typicalResponseParameters);
-        }
-        boolean prettyPrint = ApiParameterHelper.prettyPrint(uriInfo.getQueryParameters());
-
-        SavingAccountData account = null;
-        // this.savingAccountReadPlatformService.retrieveNewSavingsAccountDetails(clientId,
-        // productId);
-
-        return this.apiJsonSerializerService.serializeSavingAccountsDataToJson(prettyPrint, responseParameters, account);
-    }
-
+    	context.authenticatedUser().validateHasReadPermission(entityType);
+    	
+		Set<String> responseParameters = ApiParameterHelper.extractFieldsForResponseIfProvided(uriInfo.getQueryParameters());
+		if (responseParameters.isEmpty()) {
+			responseParameters.addAll(typicalResponseParameters);
+		}
+		boolean prettyPrint = ApiParameterHelper.prettyPrint(uriInfo.getQueryParameters());
+		
+		SavingAccountData account = null;
+//				this.savingAccountReadPlatformService.retrieveNewSavingsAccountDetails(clientId, productId);
+		
+		return this.apiJsonSerializerService.serializeSavingAccountsDataToJson(prettyPrint, responseParameters, account);
+	}
+	
     private boolean is(final String commandParam, final String commandValue) {
         return StringUtils.isNotBlank(commandParam) && commandParam.trim().equalsIgnoreCase(commandValue);
     }
+
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsaccount/command/CalculateSavingScheduleCommand.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsaccount/command/CalculateSavingScheduleCommand.java
@@ -56,4 +56,5 @@ public class CalculateSavingScheduleCommand {
         return this.tenure;
     }
 
+
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsaccount/command/SavingAccountCommand.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsaccount/command/SavingAccountCommand.java
@@ -231,7 +231,6 @@ public class SavingAccountCommand {
     public boolean isPartialDepositAllowedChanged() {
         return this.modifiedParameters.contains("isPartialDepositAllowed");
     }
-
     public boolean isPayEveryChanged() {
         return this.modifiedParameters.contains("payEvery");
     }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsaccount/data/SavingSchedulePeriodData.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsaccount/data/SavingSchedulePeriodData.java
@@ -39,4 +39,5 @@ public class SavingSchedulePeriodData {
         return this.depositPaid;
     }
 
+
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsaccount/domain/DepositScheduleDateGenerator.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsaccount/domain/DepositScheduleDateGenerator.java
@@ -6,6 +6,8 @@ import org.joda.time.LocalDate;
 import org.mifosplatform.portfolio.loanproduct.domain.PeriodFrequencyType;
 
 public interface DepositScheduleDateGenerator {
-
+	
     List<LocalDate> generate(LocalDate startDate, Integer paymentPeriods, Integer depositFrequency, PeriodFrequencyType depositFrequencyType);
+
 }
+

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsaccount/domain/SavingAccount.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsaccount/domain/SavingAccount.java
@@ -37,7 +37,7 @@ import org.mifosplatform.portfolio.savingsdepositproduct.domain.TenureTypeEnum;
 import org.mifosplatform.useradministration.domain.AppUser;
 
 @Entity
-@Table(name = "m_saving_account", uniqueConstraints = @UniqueConstraint(name = "saving_acc_external_id", columnNames = { "external_id" }))
+@Table(name = "m_saving_account", uniqueConstraints = @UniqueConstraint(name="saving_acc_external_id", columnNames = { "external_id" }))
 public class SavingAccount extends AbstractAuditableCustom<AppUser, Long> {
 
     @ManyToOne

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsaccount/domain/SavingScheduleInstallments.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsaccount/domain/SavingScheduleInstallments.java
@@ -63,3 +63,4 @@ public class SavingScheduleInstallments extends AbstractAuditableCustom<AppUser,
         this.savingAccount = account;
     }
 }
+

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsaccount/service/CalculateSavingSchedule.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsaccount/service/CalculateSavingSchedule.java
@@ -4,6 +4,6 @@ import org.mifosplatform.portfolio.savingsaccount.command.CalculateSavingSchedul
 import org.mifosplatform.portfolio.savingsaccount.data.SavingScheduleData;
 
 public interface CalculateSavingSchedule {
-
     SavingScheduleData calculateSavingSchedule(CalculateSavingScheduleCommand command);
 }
+

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsaccount/service/DefaultDepositScheduleDateGenerator.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsaccount/service/DefaultDepositScheduleDateGenerator.java
@@ -45,4 +45,5 @@ public class DefaultDepositScheduleDateGenerator implements DepositScheduleDateG
 
         return duePaymentPeriodDates;
     }
+
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsaccount/service/SavingAccountAssembler.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsaccount/service/SavingAccountAssembler.java
@@ -215,4 +215,5 @@ public class SavingAccountAssembler {
         List<DepositAccountStatus> allowedDepositStatuses = Arrays.asList(DepositAccountStatus.values());
         return new DepositLifecycleStateMachineImpl(allowedDepositStatuses);
     }
+
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsaccount/service/SavingScheduleGenerator.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsaccount/service/SavingScheduleGenerator.java
@@ -48,4 +48,5 @@ public class SavingScheduleGenerator {
         return new SavingScheduleData(currencyData, totalDeposit.getAmount(), periods);
     }
 
+
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsdepositaccount/data/DepositAccountData.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsdepositaccount/data/DepositAccountData.java
@@ -65,11 +65,16 @@ public class DepositAccountData {
     private final boolean isLockinPeriodAllowed;
     private final Integer lockinPeriod;
     private final EnumOptionData lockinPeriodType;
-
+    
     private final BigDecimal availableInterest;
-    private final BigDecimal interestPostedAmount;
-    private final LocalDate lastInterestPostedDate;
-    private final LocalDate nextInterestPostedDate;
+	private final BigDecimal interestPostedAmount;
+	private final LocalDate lastInterestPostedDate; 
+	private final LocalDate nextInterestPostedDate;
+	
+	private final String imageKey;
+	private String printFDdetailsLocation;
+	private final String fatherName;
+	private final String address;
 
     /*
      * used when returning account template data but only a clientId is passed,
@@ -129,6 +134,12 @@ public class DepositAccountData {
         this.interestPostedAmount = BigDecimal.ZERO;
         this.lastInterestPostedDate = null;
         this.nextInterestPostedDate = null;
+        
+        this.imageKey = null;
+		this.printFDdetailsLocation = null;
+		this.fatherName = null;
+		this.address = null;
+
     }
 
     public DepositAccountData(final DepositAccountData account, final List<EnumOptionData> interestCompoundedEveryPeriodTypeOptions,
@@ -181,6 +192,11 @@ public class DepositAccountData {
         this.interestPostedAmount = account.getInterestPostedAmount();
         this.lastInterestPostedDate = account.getLastInterestPostedDate();
         this.nextInterestPostedDate = account.getNextInterestPostedDate();
+        
+        this.imageKey = account.getImageKey();
+        this.printFDdetailsLocation = account.getPrintFDdetailsLocation();
+        this.fatherName=account.getFatherName();
+        this.address=account.getAddress();
     }
 
     public DepositAccountData(final DepositAccountData account, final DepositPermissionData permissions,
@@ -233,6 +249,10 @@ public class DepositAccountData {
         this.interestPostedAmount = account.getInterestPostedAmount();
         this.lastInterestPostedDate = account.getLastInterestPostedDate();
         this.nextInterestPostedDate = account.getNextInterestPostedDate();
+        this.imageKey = account.getImageKey();
+        this.printFDdetailsLocation = account.getPrintFDdetailsLocation();
+        this.fatherName=account.getFatherName();
+        this.address=account.getAddress();
     }
 
     public DepositAccountData(final Long id, final String externalId, final EnumOptionData status, final Long clientId,
@@ -245,7 +265,8 @@ public class DepositAccountData {
             final LocalDate rejectedonDate, final LocalDate closedonDate, final boolean isInterestWithdrawable,
             final BigDecimal interestPaid, final boolean interestCompoundingAllowed, final boolean isLockinPeriodAllowed,
             final Integer lockinPeriod, final EnumOptionData lockinPeriodType, final BigDecimal availableInterest,
-            final BigDecimal interestPostedAmount, final LocalDate lastInterestPostedDate, final LocalDate nextInterestPostedDate) {
+            final BigDecimal interestPostedAmount, final LocalDate lastInterestPostedDate, final LocalDate nextInterestPostedDate,
+            final String fatherName, final String address, final String imageKey) {
         this.id = id;
         this.externalId = externalId;
         this.status = status;
@@ -295,6 +316,11 @@ public class DepositAccountData {
         this.interestPostedAmount = interestPostedAmount;
         this.lastInterestPostedDate = lastInterestPostedDate;
         this.nextInterestPostedDate = nextInterestPostedDate;
+        
+        this.imageKey = imageKey;
+        this.fatherName = fatherName;
+        this.address = address;
+        this.printFDdetailsLocation = null;
     }
 
     public DepositAccountData(final Long clientId, final String clientName, final Long productId, final String productName,
@@ -350,6 +376,11 @@ public class DepositAccountData {
         this.interestPostedAmount = BigDecimal.ZERO;
         this.lastInterestPostedDate = null;
         this.nextInterestPostedDate = null;
+        
+        this.imageKey = null;
+        this.printFDdetailsLocation = null;
+        this.fatherName=null;
+        this.address=null;
     }
 
     public Long getId() {
@@ -524,7 +555,27 @@ public class DepositAccountData {
         return this.nextInterestPostedDate;
     }
 
-    private BigDecimal determineAvailableInterestForWithdrawal(final DepositAccountData account) {
+    public String getPrintFDdetailsLocation() {
+		return this.printFDdetailsLocation;
+	}
+
+	public void setPrintFDdetailsLocation(String printFDdetailsLocation) {
+		this.printFDdetailsLocation = printFDdetailsLocation;
+	}
+
+	public String getImageKey() {
+		return this.imageKey;
+	}
+
+	public String getFatherName() {
+		return this.fatherName;
+	}
+
+	public String getAddress() {
+		return this.address;
+	}
+
+	private BigDecimal determineAvailableInterestForWithdrawal(final DepositAccountData account) {
         BigDecimal availableInterestForWithdrawal = BigDecimal.ZERO;
 
         if (this.status != null) {
@@ -582,4 +633,5 @@ public class DepositAccountData {
         return BigDecimal.valueOf(depsoitAmount.doubleValue() * days.doubleValue() * interestRateForOneDay.doubleValue());
 
     }
+
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsdepositaccount/data/DepositAccountsForLookup.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsdepositaccount/data/DepositAccountsForLookup.java
@@ -13,3 +13,4 @@ public class DepositAccountsForLookup {
     }
 
 }
+

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsdepositaccount/domain/DepositAccountTransaction.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsdepositaccount/domain/DepositAccountTransaction.java
@@ -70,6 +70,14 @@ public class DepositAccountTransaction extends AbstractPersistable<Long> {
         this.interest = interest;
         this.total = amount.doubleValue() == 0 ? new BigDecimal(0) : amount.add(interest);
     }
+    
+	private DepositAccountTransaction(DepositAccountTransactionType type, final BigDecimal amount, final LocalDate date, final BigDecimal interest, final BigDecimal total) {
+		this.typeOf = type;
+        this.amount = amount;
+		this.dateOf = date.toDateMidnight().toDate();
+		this.interest = interest;
+		this.total = total;
+	}
 
     public Date getDateOf() {
         return dateOf;
@@ -101,7 +109,7 @@ public class DepositAccountTransaction extends AbstractPersistable<Long> {
                         : interest.getAmount());
     }
 
-    public static DepositAccountTransaction withdraw(Money amount, LocalDate paymentDate, Money interest) {
+   /* public static DepositAccountTransaction withdraw(Money amount, LocalDate paymentDate, Money interest) {
         return new DepositAccountTransaction(DepositAccountTransactionType.WITHDRAW, amount == null ? new BigDecimal(0)
                 : amount.getAmount(), paymentDate, interest == null ? new BigDecimal(0) : interest.getAmount());
     }
@@ -109,9 +117,20 @@ public class DepositAccountTransaction extends AbstractPersistable<Long> {
     public static DepositAccountTransaction postInterest(Money depositAmount, LocalDate paymentDate, Money interest) {
         return new DepositAccountTransaction(DepositAccountTransactionType.INTEREST_POSTING, depositAmount == null ? new BigDecimal(0)
                 : depositAmount.getAmount(), paymentDate, interest == null ? new BigDecimal(0) : interest.getAmount());
-    }
+    }*/
+    
+    public static DepositAccountTransaction withdraw(Money amount, LocalDate paymentDate, Money interest, BigDecimal total) {
+		return new DepositAccountTransaction(DepositAccountTransactionType.WITHDRAW, amount == null ? new BigDecimal(0) : amount.getAmount(), paymentDate, interest==null ? new BigDecimal(0) : interest.getAmount(),total);
+
+	}
+	
+	public static DepositAccountTransaction postInterest(Money depositAmount, LocalDate paymentDate, Money interest, BigDecimal total) {
+		return new DepositAccountTransaction(DepositAccountTransactionType.INTEREST_POSTING, depositAmount == null ? new BigDecimal(0) : depositAmount.getAmount(), paymentDate, interest==null ? new BigDecimal(0) : interest.getAmount(),total);
+
+	}
 
     public void updateAccount(DepositAccount depositAccount) {
         this.depositAccount = depositAccount;
     }
+
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsdepositaccount/domain/DepositAccountTransactionType.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsdepositaccount/domain/DepositAccountTransactionType.java
@@ -7,51 +7,55 @@ public enum DepositAccountTransactionType {
     WITHDRAW(2, "depositTransactionType.withdraw"), //
     REVERSAL(3, "depositTransactionType.reversal"), INTEREST_POSTING(4, "depositTransactionType.interestPosting");
 
+
     private final Integer value;
     private final String code;
 
     private DepositAccountTransactionType(final Integer value, final String code) {
-        this.value = value;
-        this.code = code;
-    }
 
-    public Integer getValue() {
-        return value;
-    }
+		this.value=value;
+		this.code=code;
+	}
 
-    public String getCode() {
-        return code;
-    }
+	public Integer getValue() {
+		return value;
+	}
 
-    public static DepositAccountTransactionType fromInt(final Integer transactionType) {
+	public String getCode() {
+		return code;
+	}
+    
+    public static DepositAccountTransactionType fromInt(final Integer transactionType){
+    	
+    	if (transactionType == null) {
+			return DepositAccountTransactionType.INVALID;
+		}
+    	
+    	DepositAccountTransactionType depositTransactionType=null;
+    	switch (transactionType) {
+		case 1:
+			depositTransactionType=DepositAccountTransactionType.DEPOSIT;
+			break;
+			
+		case 2:
+			depositTransactionType=DepositAccountTransactionType.WITHDRAW;
+			break;
+			
+		case 3:
+			depositTransactionType=DepositAccountTransactionType.REVERSAL;
+			break;
+			
+		case 4:
+			depositTransactionType=DepositAccountTransactionType.INTEREST_POSTING;
+			break;	
+			
+		default :
+			depositTransactionType=DepositAccountTransactionType.INVALID;
+			break;
 
-        if (transactionType == null) { return DepositAccountTransactionType.INVALID; }
-
-        DepositAccountTransactionType depositTransactionType = null;
-        switch (transactionType) {
-            case 1:
-                depositTransactionType = DepositAccountTransactionType.DEPOSIT;
-            break;
-
-            case 2:
-                depositTransactionType = DepositAccountTransactionType.WITHDRAW;
-            break;
-
-            case 3:
-                depositTransactionType = DepositAccountTransactionType.REVERSAL;
-            break;
-
-            case 4:
-                depositTransactionType = DepositAccountTransactionType.INTEREST_POSTING;
-            break;
-
-            default:
-                depositTransactionType = DepositAccountTransactionType.INVALID;
-            break;
-
-        }
-
-        return depositTransactionType;
+		}
+    	
+    	return depositTransactionType;
     }
 
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsdepositaccount/service/DepositAccountAssembler.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsdepositaccount/service/DepositAccountAssembler.java
@@ -334,4 +334,5 @@ public class DepositAccountAssembler {
     public void postInterest(DepositAccount account) {
         account.postInterestForDepositAccount(account, this.fixedTermDepositInterestCalculator);
     }
+
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsdepositaccount/service/DepositAccountReadPlatformService.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsdepositaccount/service/DepositAccountReadPlatformService.java
@@ -21,3 +21,4 @@ public interface DepositAccountReadPlatformService {
 
     Collection<DepositAccountsForLookup> retrieveDepositAccountForLookup();
 }
+

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsdepositaccount/service/DepositAccountReadPlatformServiceImpl.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsdepositaccount/service/DepositAccountReadPlatformServiceImpl.java
@@ -132,23 +132,27 @@ public class DepositAccountReadPlatformServiceImpl implements DepositAccountRead
     private static final class DepositAccountMapper implements RowMapper<DepositAccountData> {
 
         public String schema() {
-            return "da.id as id, da.external_id as externalId, da.client_id as clientId, da.product_id as productId, "
-                    + " da.currency_code as currencyCode, da.currency_digits as currencyDigits, "
-                    + " da.deposit_amount as depositAmount, da.status_enum as statusId, "
-                    + " da.maturity_nominal_interest_rate as interestRate, da.tenure_months as termInMonths, da.projected_commencement_date as projectedCommencementDate,"
-                    + " da.actual_commencement_date as actualCommencementDate, da.matures_on_date as maturedOn,"
-                    + " da.projected_interest_accrued_on_maturity as projectedInterestAccrued, da.actual_interest_accrued as actualInterestAccrued, "
-                    + " da.projected_total_maturity_amount as projectedMaturityAmount, da.actual_total_amount as actualMaturityAmount, "
-                    + " da.interest_compounded_every as interestCompoundedEvery, da.interest_compounded_every_period_enum as interestCompoundedEveryPeriodType, "
-                    + " da.is_renewal_allowed as renewalAllowed, da.is_preclosure_allowed as preClosureAllowed, da.pre_closure_interest_rate as preClosureInterestRate, "
-                    + " da.withdrawnon_date as withdrawnonDate, da.rejectedon_date as rejectedonDate, da.closedon_date as closedonDate, "
-                    + " da.interest_paid as interestPaid, da.is_interest_withdrawable as isInterestWithdrawable, da.is_compounding_interest_allowed as interestCompoundingAllowed, "
-                    + " da.is_lock_in_period_allowed as isLockinPeriodAllowed, da.lock_in_period as lockinPeriod, da.lock_in_period_type lockinPeriodType, "
-                    + " da.available_interest as availableInterest, da.interest_posted_amount as interestPostedAmount, da.last_interest_posted_date as lastInterestPostedDate, da.next_interest_posting_date as nextInterestPostedDate,"
-                    + " c.firstname as firstname, c.lastname as lastname, pd.name as productName,"
-                    + " curr.name as currencyName, curr.internationalized_name_code as currencyNameCode, curr.display_symbol as currencyDisplaySymbol "
-                    + " from m_deposit_account da " + " join m_currency curr on curr.code = da.currency_code "
-                    + " join m_client c on c.id = da.client_id " + " join m_product_deposit pd on pd.id = da.product_id";
+            return "da.id as id, da.external_id as externalId, da.client_id as clientId, da.product_id as productId, " 
+    				+  " da.currency_code as currencyCode, da.currency_digits as currencyDigits, " 
+    				+  " da.deposit_amount as depositAmount, da.status_enum as statusId, "	
+    				+  " da.maturity_nominal_interest_rate as interestRate, da.tenure_months as termInMonths, da.projected_commencement_date as projectedCommencementDate," 
+    				+  " da.actual_commencement_date as actualCommencementDate, da.matures_on_date as maturedOn,"
+    				+  " da.projected_interest_accrued_on_maturity as projectedInterestAccrued, da.actual_interest_accrued as actualInterestAccrued, "
+    				+  " da.projected_total_maturity_amount as projectedMaturityAmount, da.actual_total_amount as actualMaturityAmount, "
+    				+  " da.interest_compounded_every as interestCompoundedEvery, da.interest_compounded_every_period_enum as interestCompoundedEveryPeriodType, "
+    				+  " da.is_renewal_allowed as renewalAllowed, da.is_preclosure_allowed as preClosureAllowed, da.pre_closure_interest_rate as preClosureInterestRate, "
+    				+  " da.withdrawnon_date as withdrawnonDate, da.rejectedon_date as rejectedonDate, da.closedon_date as closedonDate, " 
+    				+  " da.interest_paid as interestPaid, da.is_interest_withdrawable as isInterestWithdrawable, da.is_compounding_interest_allowed as interestCompoundingAllowed, "
+    				+  " da.is_lock_in_period_allowed as isLockinPeriodAllowed, da.lock_in_period as lockinPeriod, da.lock_in_period_type lockinPeriodType, "
+    				+  " da.available_interest as availableInterest, da.interest_posted_amount as interestPostedAmount, da.last_interest_posted_date as lastInterestPostedDate, da.next_interest_posting_date as nextInterestPostedDate,"
+    				+  " c.firstname as firstname, c.lastname as lastname, pd.name as productName, c.image_key as imageKey, "
+    				+  " curr.name as currencyName, curr.internationalized_name_code as currencyNameCode, curr.display_symbol as currencyDisplaySymbol, "
+    				+  " ecd.father_name as fatherName, ecd.client_address as clientAddress "
+    				+  " from m_deposit_account da " 
+    				+  " join m_currency curr on curr.code = da.currency_code " 
+    				+  " join m_client c on c.id = da.client_id " 
+    				+  " join m_product_deposit pd on pd.id = da.product_id"
+    				+  " left join extra_client_details ecd on da.client_id = ecd.client_id "; 
         }
 
         @Override
@@ -208,11 +212,14 @@ public class DepositAccountReadPlatformServiceImpl implements DepositAccountRead
             Integer lockinPeriod = JdbcSupport.getInteger(rs, "lockinPeriod");
             Integer lockinPeriodTypeValue = JdbcSupport.getInteger(rs, "lockinPeriodType");
             EnumOptionData lockinPeriodType = SavingsDepositEnumerations.interestCompoundingPeriodType(lockinPeriodTypeValue);
-
+            
             BigDecimal availableInterest = rs.getBigDecimal("availableInterest");
-            BigDecimal interestPostedAmount = rs.getBigDecimal("interestPostedAmount");
-            LocalDate lastInterestPostedDate = JdbcSupport.getLocalDate(rs, "lastInterestPostedDate");
-            LocalDate nextInterestPostedDate = JdbcSupport.getLocalDate(rs, "nextInterestPostedDate");
+			BigDecimal interestPostedAmount = rs.getBigDecimal("interestPostedAmount");
+			LocalDate lastInterestPostedDate = JdbcSupport.getLocalDate(rs, "lastInterestPostedDate");
+			LocalDate nextInterestPostedDate = JdbcSupport.getLocalDate(rs, "nextInterestPostedDate");
+			String imageKey = rs.getString("imageKey");
+			String fatherName = rs.getString("fatherName");
+			String address = rs.getString("clientAddress");
 
             return new DepositAccountData(id, externalId, status, clientId, clientName, productId, productName, currencyData,
                     depositAmount, interestRate, termInMonths, projectedCommencementDate, actualCommencementDate, maturedOn,
@@ -220,15 +227,15 @@ public class DepositAccountReadPlatformServiceImpl implements DepositAccountRead
                     interestCompoundedEvery, interestCompoundedEveryPeriodType, renewalAllowed, preClosureAllowed, preClosureInterestRate,
                     withdrawnonDate, rejectedonDate, closedonDate, isInterestWithdrawable, interestPaid, interestCompoundingAllowed,
                     isLockinPeriodAllowed, lockinPeriod, lockinPeriodType, availableInterest, interestPostedAmount, lastInterestPostedDate,
-                    nextInterestPostedDate);
+                    nextInterestPostedDate,fatherName,address,imageKey);
         }
     }
 
     private static final class DepositAccountTransactionMapper implements RowMapper<DepositAccountTransactionData> {
 
         public String schema() {
-            return " txn.id as transactionId, txn.deposit_account_id as accountId, txn.transaction_type_enum as transactionType, txn.transaction_date as transactionDate, txn.amount as transactionAmount, txn.interest as interestAmount "
-                    + " from m_deposit_account_transaction txn";
+            return " txn.id as transactionId, txn.deposit_account_id as accountId, txn.transaction_type_enum as transactionType, txn.transaction_date as transactionDate, txn.amount as transactionAmount, txn.interest as interestAmount, " 
+    				+  "txn.total as total from m_deposit_account_transaction txn";
         }
 
         @Override
@@ -241,7 +248,7 @@ public class DepositAccountReadPlatformServiceImpl implements DepositAccountRead
             LocalDate transactionDate = JdbcSupport.getLocalDate(rs, "transactionDate");
             BigDecimal transactionAmount = rs.getBigDecimal("transactionAmount");
             BigDecimal interestAmount = rs.getBigDecimal("interestAmount");
-            BigDecimal total = transactionAmount.add(interestAmount);
+            BigDecimal total = rs.getBigDecimal("total");
 
             return new DepositAccountTransactionData(transactionId, accountId, transactionType, transactionDate, transactionAmount,
                     interestAmount, total);
@@ -255,18 +262,7 @@ public class DepositAccountReadPlatformServiceImpl implements DepositAccountRead
         boolean undoApprovalAllowed = (depositAccountData.getStatus().getId().equals(300L));
         boolean renewelAllowed = false;
         if (depositAccountData.getMaturedOn() != null) {
-            if (new LocalDate().isAfter(depositAccountData.getMaturedOn())/*
-                                                                           * ||
-                                                                           * depositAccountData
-                                                                           * .
-                                                                           * getMaturedOn
-                                                                           * ().
-                                                                           * isEqual
-                                                                           * (
-                                                                           * new
-                                                                           * LocalDate
-                                                                           * ())
-                                                                           */) {
+            if (new LocalDate().isAfter(depositAccountData.getMaturedOn())/* || depositAccountData.getMaturedOn().isEqual(new LocalDate()) */) {
                 renewelAllowed = depositAccountData.isRenewalAllowed();
             }
         }
@@ -312,4 +308,5 @@ public class DepositAccountReadPlatformServiceImpl implements DepositAccountRead
         }
 
     }
+
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsdepositaccount/service/DepositAccountTransactionEnumerations.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsdepositaccount/service/DepositAccountTransactionEnumerations.java
@@ -27,6 +27,11 @@ public class DepositAccountTransactionEnumerations {
                 optionData = new EnumOptionData(DepositAccountTransactionType.REVERSAL.getValue().longValue(),
                         DepositAccountTransactionType.REVERSAL.getCode(), "Revarsal");
             break;
+            
+            case INTEREST_POSTING:
+    			optionData=new EnumOptionData(DepositAccountTransactionType.INTEREST_POSTING.getValue().longValue(), DepositAccountTransactionType.INTEREST_POSTING.getCode(), "Interest posting");
+    			break;
+    			
             default:
                 optionData = new EnumOptionData(DepositAccountTransactionType.INVALID.getValue().longValue(),
                         DepositAccountTransactionType.INVALID.getCode(), "Invalid Transaction");

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsdepositaccount/service/DepositAccountWritePlatformService.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsdepositaccount/service/DepositAccountWritePlatformService.java
@@ -55,4 +55,5 @@ public interface DepositAccountWritePlatformService {
 
     @PreAuthorize(value = "hasAnyRole('ALL_FUNCTIONS', 'PORTFOLIO_MANAGEMENT_SUPER_USER')")
     EntityIdentifier postInterestToDepositAccount(Collection<DepositAccountsForLookup> accounts);
+
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsdepositaccount/service/DepositAccountWritePlatformServiceJpaRepositoryImpl.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsdepositaccount/service/DepositAccountWritePlatformServiceJpaRepositoryImpl.java
@@ -333,9 +333,9 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
         if (account == null || account.isDeleted()) { throw new DepositAccountNotFoundException(command.getAccountId()); }
         if (account.isInterestWithdrawable() && !account.isInterestCompoundingAllowed()) {
 
-            BigDecimal totalAvailableInterestForWithdrawal = getTotalWithdrawableInterestAvailable(account);
-            BigDecimal interestPaid = account.getInterstPaid();
-            BigDecimal remainInterestForWithdrawal = totalAvailableInterestForWithdrawal.subtract(interestPaid);
+           // BigDecimal totalAvailableInterestForWithdrawal = getTotalWithdrawableInterestAvailable(account);
+           // BigDecimal interestPaid = account.getInterstPaid();
+            BigDecimal remainInterestForWithdrawal = account.getAvailableInterest(); //totalAvailableInterestForWithdrawal.subtract(interestPaid);
 
             if (remainInterestForWithdrawal.doubleValue() > 0) {
                 if (remainInterestForWithdrawal.doubleValue() >= command.getWithdrawInterest().doubleValue()
@@ -357,13 +357,13 @@ public class DepositAccountWritePlatformServiceJpaRepositoryImpl implements Depo
         return new EntityIdentifier(account.getId());
     }
 
-    private BigDecimal getTotalWithdrawableInterestAvailable(DepositAccount account) {
+/*    private BigDecimal getTotalWithdrawableInterestAvailable(DepositAccount account) {
         BigDecimal interstGettingForPeriod = BigDecimal.valueOf(account.getAccuredInterest().getAmount().doubleValue()
                 / new Double(account.getTenureInMonths()));
         Integer noOfMonthsforInterestCal = Months.monthsBetween(account.getActualCommencementDate(), new LocalDate()).getMonths();
         Integer noOfPeriods = noOfMonthsforInterestCal / account.getInterestCompoundedEvery();
         return interstGettingForPeriod.multiply(new BigDecimal(noOfPeriods));
-    }
+    }*/
 
     @Transactional
     @Override

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsdepositaccount/service/GeneratePDF.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/savingsdepositaccount/service/GeneratePDF.java
@@ -1,0 +1,73 @@
+package org.mifosplatform.portfolio.savingsdepositaccount.service;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.text.DecimalFormat;
+import java.text.SimpleDateFormat;
+
+import org.mifosplatform.infrastructure.core.service.FileUtils;
+import org.mifosplatform.portfolio.savingsdepositaccount.data.DepositAccountData;
+
+import com.lowagie.text.Document;
+import com.lowagie.text.Element;
+import com.lowagie.text.Font;
+import com.lowagie.text.FontFactory;
+import com.lowagie.text.Image;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.pdf.CMYKColor;
+import com.lowagie.text.pdf.PdfWriter;
+
+public class GeneratePDF {
+
+	private final DepositAccountData account;
+
+	public GeneratePDF(DepositAccountData account) {
+		this.account = account;
+	}
+
+	public String generatePDF() {
+
+		String fileLocation = FileUtils.MIFOSX_BASE_DIR + File.separator+ "Print_FD_Details";
+
+		/** Recursively create the directory if it does not exist **/
+		if (!new File(fileLocation).isDirectory()) {
+			new File(fileLocation).mkdirs();
+		}
+		String printFDdetailsLocation = fileLocation + File.separator + account.getId() + ".pdf";
+		SimpleDateFormat dateFormat = new SimpleDateFormat("dd-MMMM-yyyy");
+		DecimalFormat decimalFormat = new DecimalFormat("#.##");
+
+		try {
+			Document document = new Document();
+			PdfWriter.getInstance(document, new FileOutputStream(printFDdetailsLocation));
+			document.open();
+
+			Paragraph paragraph = new Paragraph("FIXED DEPOSIT CERTIFICATE ", FontFactory.getFont(FontFactory.COURIER, 14, Font.BOLD, new CMYKColor(0, 255, 0, 0)));
+
+			paragraph.setAlignment(Element.ALIGN_CENTER);
+			paragraph.setSpacingAfter(30);
+
+			document.add(paragraph);
+			Image img = Image.getInstance(account.getImageKey());
+			img.scaleAbsolute(70, 80);
+			img.setAbsolutePosition(450, 670);
+			document.add(img);
+			Font font = FontFactory.getFont(FontFactory.COURIER, 10);
+			document.add(new Paragraph("Extenal id: "+ account.getExternalId(), font));
+			document.add(new Paragraph("Created date: "+ dateFormat.format(account.getActualCommencementDate().toDate()), font));
+			document.add(new Paragraph("Mature date: " + dateFormat.format(account.getMaturedOn().toDate()), font));
+			document.add(new Paragraph("Client name: " + account.getClientName(), font));
+			document.add(new Paragraph("Amount: " + decimalFormat.format(account.getDeposit()), font));
+			document.add(new Paragraph("FD interest rate: " + decimalFormat.format(account.getMaturityInterestRate()), font));
+			document.add(new Paragraph("Preclosure interest rate: " + decimalFormat.format(account.getPreClosureInterestRate()), font));
+			document.add(new Paragraph("Tenure: " + account.getTenureInMonths(), font));
+			document.add(new Paragraph("Maturity Amount: " + decimalFormat.format(account.getActualMaturityAmount()), font));
+			document.close();
+			
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return printFDdetailsLocation;
+	}
+
+}


### PR DESCRIPTION
In this pull as I /Shiva told in December 6 user meet the interest posting and  withdraw full application before maturity (i.e. Preclosure of FD) functionalities are changed, if the client withdraw his full posted interest and  then if he preclose it .

   According to our functionality the extra withdrawn interest should be deducted from his deposit amount .  This functionality previously achieved,  but our deployed customer have all interest postings as in years only, So he asked for change of the behavior for preclosure accounts as like this

i) Assume FD application is created 1year 2months ago,  and the interest is posted every 1yr.
   After 1yr of FD Creation the interest is posted, he withdraws his interest,  then after 2months he came and want to close the FD, then the interest is calculated for two months on preclosure interest rate, now he will get full deposit+preclosure interest amount for 2months (This is our customer specific)
