### PR TITLE
Un-assign loan officer from loan account

### DIFF
--- a/mifosng-db/patches/03-patch_add_remove_loanofficer_permission.sql
+++ b/mifosng-db/patches/03-patch_add_remove_loanofficer_permission.sql
@@ -1,0 +1,1 @@
+INSERT INTO `m_permission` (`id`, `grouping`, `code`, `entity_name`, `action_name`, `can_maker_checker`) VALUES (358, 'transaction_loan', 'REMOVELOANOFFICER_LOAN', 'LOAN', 'REMOVELOANOFFICER', 1);

--- a/mifosng-provider/src/main/java/org/mifosplatform/commands/domain/CommandWrapper.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/commands/domain/CommandWrapper.java
@@ -297,6 +297,10 @@ public class CommandWrapper {
         return this.actionName.equalsIgnoreCase("UPDATELOANOFFICER") && this.entityName.equalsIgnoreCase("LOAN");
     }
 
+    public boolean isRemoveLoanOfficer() {
+        return this.actionName.equalsIgnoreCase("REMOVELOANOFFICER") && this.entityName.equalsIgnoreCase("LOAN");
+    }
+    
     public boolean isBulkUpdateLoanOfficer() {
         return this.actionName.equalsIgnoreCase("BULKREASSIGN") && this.entityName.equalsIgnoreCase("LOAN");
     }

--- a/mifosng-provider/src/main/java/org/mifosplatform/commands/service/CommandWrapperBuilder.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/commands/service/CommandWrapperBuilder.java
@@ -549,6 +549,15 @@ public class CommandWrapperBuilder {
         this.href = "/loans/" + loanId;
         return this;
     }
+    
+    public CommandWrapperBuilder unassignLoanOfficer(final Long loanId) {
+        this.actionName = "REMOVELOANOFFICER";
+        this.entityName = "LOAN";
+        this.entityId = null;
+        this.loanId = loanId;
+        this.href = "/loans/" + loanId;
+        return this;
+    }
 
     public CommandWrapperBuilder assignLoanOfficersInBulk() {
         this.actionName = "BULKREASSIGN";

--- a/mifosng-provider/src/main/java/org/mifosplatform/commands/service/SynchronousCommandProcessingService.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/commands/service/SynchronousCommandProcessingService.java
@@ -281,6 +281,8 @@ public class SynchronousCommandProcessingService implements CommandProcessingSer
                 handler = applicationContext.getBean("closeLoanAsRescheduledCommandHandler", NewCommandSourceHandler.class);
             } else if (wrapper.isUpdateLoanOfficer()) {
                 handler = applicationContext.getBean("updateLoanOfficerCommandHandler", NewCommandSourceHandler.class);
+            } else if (wrapper.isRemoveLoanOfficer()) {
+                handler = applicationContext.getBean("removeLoanOfficerCommandHandler", NewCommandSourceHandler.class);
             } else if (wrapper.isBulkUpdateLoanOfficer()) {
                 handler = applicationContext.getBean("bulkUpdateLoanOfficerCommandHandler", NewCommandSourceHandler.class);
             } else if (wrapper.isCreate()) {

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/api/LoansApiResource.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/api/LoansApiResource.java
@@ -457,4 +457,18 @@ public class LoansApiResource {
 
         return this.toApiJsonSerializer.serialize(result);
     }
+    
+    @POST
+    @Path("{loanId}/unassign")
+    @Consumes({ MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_JSON })
+    public String unassignLoanOfficer(@PathParam("loanId") final Long loanId, final String apiRequestBodyAsJson) {
+
+        final CommandWrapper commandRequest = new CommandWrapperBuilder().unassignLoanOfficer(loanId).withJson(apiRequestBodyAsJson)
+                .build();
+
+        final CommandProcessingResult result = this.commandsSourceWritePlatformService.logCommandSource(commandRequest);
+
+        return this.toApiJsonSerializer.serialize(result);
+    }
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/command/LoanUpdateCommand.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/command/LoanUpdateCommand.java
@@ -1,0 +1,33 @@
+package org.mifosplatform.portfolio.loanaccount.command;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.joda.time.LocalDate;
+import org.mifosplatform.infrastructure.core.data.ApiParameterError;
+import org.mifosplatform.infrastructure.core.data.DataValidatorBuilder;
+import org.mifosplatform.infrastructure.core.exception.PlatformApiDataValidationException;
+
+/**
+ * Immutable command for loan transactions.
+ */
+public class LoanUpdateCommand {
+
+    private final LocalDate unassignedDate;
+
+    public LoanUpdateCommand(final LocalDate unassignDate) {
+        this.unassignedDate = unassignDate;
+    }
+
+    public void validate() {
+
+        List<ApiParameterError> dataValidationErrors = new ArrayList<ApiParameterError>();
+
+        DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors).resource("loan.transaction");
+
+        baseDataValidator.reset().parameter("unassignedDate").value(this.unassignedDate).notNull();
+
+        if (!dataValidationErrors.isEmpty()) { throw new PlatformApiDataValidationException("validation.msg.validation.errors.exist",
+                "Validation errors exist.", dataValidationErrors); }
+    }
+}

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/command/UpdateLoanOfficerCommand.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/command/UpdateLoanOfficerCommand.java
@@ -9,7 +9,8 @@ import org.mifosplatform.infrastructure.core.data.DataValidatorBuilder;
 import org.mifosplatform.infrastructure.core.exception.PlatformApiDataValidationException;
 
 /**
- * Immutable data object for updating relationship between loan officer and a loan.
+ * Immutable data object for updating relationship between loan officer and a
+ * loan.
  */
 public class UpdateLoanOfficerCommand {
 
@@ -26,17 +27,18 @@ public class UpdateLoanOfficerCommand {
         this.loans = null;
     }
 
-    public UpdateLoanOfficerCommand(final Long fromLoanOfficerId, final Long toLoanOfficerId, final LocalDate assignmentDate, final String[] loans) {
+    public UpdateLoanOfficerCommand(final Long fromLoanOfficerId, final Long toLoanOfficerId, final LocalDate assignmentDate,
+            final String[] loans) {
         this.fromLoanOfficerId = fromLoanOfficerId;
         this.toLoanOfficerId = toLoanOfficerId;
         this.assignmentDate = assignmentDate;
         this.loans = loans;
     }
-    
-    public void validateForBulkLoanReassignment() {
-        List<ApiParameterError> dataValidationErrors = new ArrayList<ApiParameterError>();
 
-        DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors).resource("loans.reassignment");
+    public void validateForBulkLoanReassignment() {
+        final List<ApiParameterError> dataValidationErrors = new ArrayList<ApiParameterError>();
+
+        final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors).resource("loans.reassignment");
 
         baseDataValidator.reset().parameter("fromLoanOfficerId").value(this.fromLoanOfficerId).notNull().integerGreaterThanZero();
         baseDataValidator.reset().parameter("toLoanOfficerId").value(this.toLoanOfficerId).notNull().integerGreaterThanZero()
@@ -51,9 +53,9 @@ public class UpdateLoanOfficerCommand {
     }
 
     public void validateForLoanReassignment() {
-        List<ApiParameterError> dataValidationErrors = new ArrayList<ApiParameterError>();
+        final List<ApiParameterError> dataValidationErrors = new ArrayList<ApiParameterError>();
 
-        DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors).resource("loans.reassignment");
+        final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors).resource("loans.reassignment");
 
         baseDataValidator.reset().parameter("toLoanOfficerId").value(this.toLoanOfficerId).notNull().integerGreaterThanZero()
                 .notSameAsParameter("fromLoanOfficerId", this.fromLoanOfficerId);

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/domain/Loan.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/domain/Loan.java
@@ -1941,6 +1941,18 @@ public class Loan extends AbstractAuditableCustom<AppUser, Long> {
         }
     }
 
+    
+    public void removeLoanOfficer(final LocalDate updatedDate) {
+
+        final LoanOfficerAssignmentHistory latestHistoryRecord = findLatestIncompleteHistoryRecord();
+
+        if (latestHistoryRecord != null) {
+            latestHistoryRecord.updateEndDate(updatedDate);
+        }
+            
+        this.loanofficer = null;
+    }
+    
     private LoanOfficerAssignmentHistory findLatestIncompleteHistoryRecord() {
 
         LoanOfficerAssignmentHistory latestRecordWithNoEndDate = null;
@@ -2006,4 +2018,9 @@ public class Loan extends AbstractAuditableCustom<AppUser, Long> {
     public Long productId() {
         return this.loanProduct.getId();
     }
+    
+    public Staff getLoanOfficer() {
+        return this.loanofficer;
+    }
+
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/exception/UnassignLoanOfficerException.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/exception/UnassignLoanOfficerException.java
@@ -1,0 +1,11 @@
+package org.mifosplatform.portfolio.loanaccount.exception;
+
+import org.mifosplatform.infrastructure.core.exception.AbstractPlatformDomainRuleException;
+
+public class UnassignLoanOfficerException extends AbstractPlatformDomainRuleException {
+
+    public UnassignLoanOfficerException(final Long loanId) {
+        super("error.msg.loan.not.assigned.to.loan.officer", "Loan with identifier " + loanId
+                + " is not assigned to any loan officer.", loanId);
+    }
+}

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/handler/RemoveLoanOfficerCommandHandler.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/handler/RemoveLoanOfficerCommandHandler.java
@@ -1,0 +1,27 @@
+package org.mifosplatform.portfolio.loanaccount.handler;
+
+import org.mifosplatform.commands.handler.NewCommandSourceHandler;
+import org.mifosplatform.infrastructure.core.api.JsonCommand;
+import org.mifosplatform.infrastructure.core.data.CommandProcessingResult;
+import org.mifosplatform.portfolio.loanaccount.service.LoanWritePlatformService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RemoveLoanOfficerCommandHandler implements NewCommandSourceHandler {
+
+    private final LoanWritePlatformService writePlatformService;
+
+    @Autowired
+    public RemoveLoanOfficerCommandHandler(final LoanWritePlatformService writePlatformService) {
+        this.writePlatformService = writePlatformService;
+    }
+
+    @Transactional
+    @Override
+    public CommandProcessingResult processCommand(final JsonCommand command) {
+
+        return this.writePlatformService.removeLoanOfficer(command.getLoanId(), command);
+    }
+}

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/serialization/LoanUpdateCommandFromApiJsonDeserializer.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/serialization/LoanUpdateCommandFromApiJsonDeserializer.java
@@ -1,0 +1,55 @@
+package org.mifosplatform.portfolio.loanaccount.serialization;
+
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+import org.joda.time.LocalDate;
+import org.mifosplatform.infrastructure.core.exception.InvalidJsonException;
+import org.mifosplatform.infrastructure.core.serialization.AbstractFromApiJsonDeserializer;
+import org.mifosplatform.infrastructure.core.serialization.FromApiJsonDeserializer;
+import org.mifosplatform.infrastructure.core.serialization.FromJsonHelper;
+import org.mifosplatform.portfolio.loanaccount.command.LoanStateTransitionCommand;
+import org.mifosplatform.portfolio.loanaccount.command.LoanUpdateCommand;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.google.gson.JsonElement;
+import com.google.gson.reflect.TypeToken;
+
+/**
+ * Implementation of {@link FromApiJsonDeserializer} for
+ * {@link LoanStateTransitionCommand}'s.
+ */
+@Component
+public final class LoanUpdateCommandFromApiJsonDeserializer extends AbstractFromApiJsonDeserializer<LoanUpdateCommand> {
+
+    /**
+     * The parameters supported for this command.
+     */
+    final Set<String> supportedParameters = new HashSet<String>(Arrays.asList("unassignedDate", "locale", "dateFormat"));
+
+    private final FromJsonHelper fromApiJsonHelper;
+
+    @Autowired
+    public LoanUpdateCommandFromApiJsonDeserializer(final FromJsonHelper fromApiJsonHelper) {
+        this.fromApiJsonHelper = fromApiJsonHelper;
+    }
+
+    @Override
+    public LoanUpdateCommand commandFromApiJson(final String json) {
+
+        if (StringUtils.isBlank(json)) { throw new InvalidJsonException(); }
+
+        final Type typeOfMap = new TypeToken<Map<String, Object>>() {}.getType();
+        this.fromApiJsonHelper.checkForUnsupportedParameters(typeOfMap, json, this.supportedParameters);
+
+        final JsonElement element = this.fromApiJsonHelper.parse(json);
+        final LocalDate unassignedDate = this.fromApiJsonHelper.extractLocalDateNamed("unassignedDate", element);
+
+        return new LoanUpdateCommand(unassignedDate);
+    }
+}

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/service/LoanWritePlatformService.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/service/LoanWritePlatformService.java
@@ -32,4 +32,6 @@ public interface LoanWritePlatformService {
     CommandProcessingResult loanReassignment(Long loanId, JsonCommand command);
 
     CommandProcessingResult bulkLoanReassignment(JsonCommand command);
+
+    CommandProcessingResult removeLoanOfficer(Long loanId, JsonCommand command);
 }


### PR DESCRIPTION
Hello Keith,

in my local machine commit message is wrong, by mistake executed commit command from history and pushed to origin. Is this a problem ?

Regarding service functionality
1) Service "unassign" the loan officer from loan just by accepting loanid and unassigned-Date
2) Add end_date in m_loan_officer_assignment_history table for this loan's latest entry with no end_date is updated by unassigned-Date
3) If you try to unassign loan officer to loan with no loan officer then it through a exception 

I have question,
unassigned-Date parameter is validated only for not null. Does service need to validate it for future date / past date ?

And is there need of bulk-unassign feature. 

Now I will start working on UI for getting unassign button.

Thanks
Nayan Ambali
