### PR TITLE
Incorp review comments

### DIFF
--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/api/GroupsApiResource.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/api/GroupsApiResource.java
@@ -74,11 +74,12 @@ public class GroupsApiResource {
     @Produces({ MediaType.APPLICATION_JSON })
     public String retrieveAllGroups(@Context final UriInfo uriInfo, @QueryParam("sqlSearch") final String sqlSearch,
             @QueryParam("officeId") final Long officeId, @QueryParam("externalId") final String externalId,
-            @QueryParam("name") final String name, @QueryParam("underHierarchy") final String hierarchy) {
+            @QueryParam("name") final String name, @QueryParam("underHierarchy") final String hierarchy,
+            @QueryParam("levelId") final Long levelId) {
 
         this.context.authenticatedUser().validateHasReadPermission("GROUP");
 
-        final String extraCriteria = getGroupExtraCriteria(sqlSearch, officeId, externalId, name, hierarchy);
+        final String extraCriteria = getGroupExtraCriteria(sqlSearch, officeId, externalId, name, hierarchy, levelId);
         final Collection<GroupData> groups = this.groupReadPlatformService.retrieveAllGroups(extraCriteria);
 
         final ApiRequestJsonSerializationSettings settings = this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());
@@ -202,7 +203,7 @@ public class GroupsApiResource {
     // clause is ambiguous
     // caused by the same name of columns in m_office and m_group tables
     private String getGroupExtraCriteria(String sqlSearch, final Long officeId, final String externalId, final String name,
-            final String hierarchy) {
+            final String hierarchy, final Long levelId) {
 
         String extraCriteria = "";
 
@@ -213,15 +214,19 @@ public class GroupsApiResource {
         }
 
         if (officeId != null) {
-            extraCriteria += " and office_id = " + officeId;
+            extraCriteria += " and g.office_id = " + officeId;
+        }
+
+        if (levelId != null) {
+            extraCriteria += " and g.level_Id = " + levelId;
         }
 
         if (externalId != null) {
-            extraCriteria += " and g.external_id like " + ApiParameterHelper.sqlEncodeString(externalId);
+            extraCriteria += " and g.external_id = " + ApiParameterHelper.sqlEncodeString(externalId);
         }
 
         if (name != null) {
-            extraCriteria += " and g.name = " + ApiParameterHelper.sqlEncodeString(name);
+            extraCriteria += " and g.name like " + ApiParameterHelper.sqlEncodeString(name + "%");
         }
 
         if (hierarchy != null) {

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/api/GroupsLevelApiResource.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/api/GroupsLevelApiResource.java
@@ -22,7 +22,7 @@ import org.mifosplatform.infrastructure.core.api.ApiRequestParameterHelper;
 import org.mifosplatform.infrastructure.core.serialization.ApiRequestJsonSerializationSettings;
 import org.mifosplatform.infrastructure.core.serialization.ToApiJsonSerializer;
 import org.mifosplatform.infrastructure.security.service.PlatformSecurityContext;
-import org.mifosplatform.portfolio.group.domain.GroupLevel;
+import org.mifosplatform.portfolio.group.data.GroupLevelData;
 import org.mifosplatform.portfolio.group.service.GroupLevelReadPlatformService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
@@ -33,17 +33,17 @@ import org.springframework.stereotype.Component;
 @Scope("singleton")
 public class GroupsLevelApiResource {
 
-    private static final Set<String> GROUPLEVEL_DATA_PARAMETERS = new HashSet<String>(Arrays.asList("parentId", "isSuperParent", "levelId",
-            "levelName", "recursable", "canHaveClients"));
+    private static final Set<String> GROUPLEVEL_DATA_PARAMETERS = new HashSet<String>(Arrays.asList("levelId", "levelName", "parentLevelId",
+            "parentLevelName", "childLevelId", "childLevelName" , "superParent" , "recursable" , "canHaveClients"));
 
     private final PlatformSecurityContext context;
     private final GroupLevelReadPlatformService groupLevelReadPlatformService;
-    private final ToApiJsonSerializer<GroupLevel> toApiJsonSerializer;
+    private final ToApiJsonSerializer<GroupLevelData> toApiJsonSerializer;
     private final ApiRequestParameterHelper apiRequestParameterHelper;
 
     @Autowired
     public GroupsLevelApiResource(final PlatformSecurityContext context, final GroupLevelReadPlatformService groupLevelReadPlatformService,
-            final ToApiJsonSerializer<GroupLevel> toApiJsonSerializer, final ApiRequestParameterHelper apiRequestParameterHelper) {
+            final ToApiJsonSerializer<GroupLevelData> toApiJsonSerializer, final ApiRequestParameterHelper apiRequestParameterHelper) {
         this.context = context;
         this.groupLevelReadPlatformService = groupLevelReadPlatformService;
         this.toApiJsonSerializer = toApiJsonSerializer;
@@ -57,7 +57,7 @@ public class GroupsLevelApiResource {
 
         this.context.authenticatedUser().validateHasReadPermission("GROUP");
 
-        final Collection<GroupLevel> groupLevel = this.groupLevelReadPlatformService.retrieveAllLevels();
+        final Collection<GroupLevelData> groupLevel = this.groupLevelReadPlatformService.retrieveAllLevels();
         final ApiRequestJsonSerializationSettings settings = this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());
 
         return this.toApiJsonSerializer.serialize(settings, groupLevel, GROUPLEVEL_DATA_PARAMETERS);

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/serialization/GroupCommandFromApiJsonDeserializer.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/serialization/GroupCommandFromApiJsonDeserializer.java
@@ -99,7 +99,7 @@ public final class GroupCommandFromApiJsonDeserializer extends AbstractFromApiJs
             baseDataValidator.reset().parameter(parentIdParameterName).value(parentId).notNull().integerGreaterThanZero();
         }
 
-        final String staffIdParameterName = "stafftId";
+        final String staffIdParameterName = "staffId";
         if (this.fromApiJsonHelper.parameterExists(staffIdParameterName, element)) {
             final Long staffId = this.fromApiJsonHelper.extractLongNamed(staffIdParameterName, element);
             baseDataValidator.reset().parameter(staffIdParameterName).value(staffId).notNull().integerGreaterThanZero();
@@ -140,7 +140,7 @@ public final class GroupCommandFromApiJsonDeserializer extends AbstractFromApiJs
             baseDataValidator.reset().parameter(parentIdParameterName).value(parentId).notNull().integerGreaterThanZero();
         }
 
-        final String staffIdParameterName = "stafftId";
+        final String staffIdParameterName = "staffId";
         if (this.fromApiJsonHelper.parameterExists(staffIdParameterName, element)) {
             final Long staffId = this.fromApiJsonHelper.extractLongNamed(staffIdParameterName, element);
             baseDataValidator.reset().parameter(staffIdParameterName).value(staffId).notNull().integerGreaterThanZero();
@@ -167,7 +167,7 @@ public final class GroupCommandFromApiJsonDeserializer extends AbstractFromApiJs
 
         final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors).resource("group");
 
-        final String staffIdParameterName = "stafftId";
+        final String staffIdParameterName = "staffId";
         if (this.fromApiJsonHelper.parameterExists(staffIdParameterName, element)) {
             final Long staffId = this.fromApiJsonHelper.extractLongNamed(staffIdParameterName, element);
             baseDataValidator.reset().parameter(staffIdParameterName).value(staffId).notNull().integerGreaterThanZero();

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/service/GroupLevelReadPlatformService.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/service/GroupLevelReadPlatformService.java
@@ -7,10 +7,10 @@ package org.mifosplatform.portfolio.group.service;
 
 import java.util.Collection;
 
-import org.mifosplatform.portfolio.group.domain.GroupLevel;
+import org.mifosplatform.portfolio.group.data.GroupLevelData;
 
 public interface GroupLevelReadPlatformService {
 
-    Collection<GroupLevel> retrieveAllLevels();
+    Collection<GroupLevelData> retrieveAllLevels();
 
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/service/GroupLevelReadPlatformServiceImpl.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/service/GroupLevelReadPlatformServiceImpl.java
@@ -5,29 +5,67 @@
  */
 package org.mifosplatform.portfolio.group.service;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.Collection;
 
+import org.mifosplatform.infrastructure.core.service.TenantAwareRoutingDataSource;
 import org.mifosplatform.infrastructure.security.service.PlatformSecurityContext;
-import org.mifosplatform.portfolio.group.domain.GroupLevel;
-import org.mifosplatform.portfolio.group.domain.GroupLevelRepository;
+import org.mifosplatform.portfolio.group.data.GroupLevelData;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Service;
 
 @Service
 public class GroupLevelReadPlatformServiceImpl implements GroupLevelReadPlatformService {
 
     private final PlatformSecurityContext context;
-    private final GroupLevelRepository groupLevelRepository;
+    private final JdbcTemplate jdbcTemplate;
+
 
     @Autowired
-    public GroupLevelReadPlatformServiceImpl(final PlatformSecurityContext context, final GroupLevelRepository groupRepository) {
+    public GroupLevelReadPlatformServiceImpl(final PlatformSecurityContext context , final TenantAwareRoutingDataSource dataSource) {
         this.context = context;
-        this.groupLevelRepository = groupRepository;
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
     }
 
     @Override
-    public Collection<GroupLevel> retrieveAllLevels() {
+    public Collection<GroupLevelData> retrieveAllLevels() {
         this.context.authenticatedUser();
-        return this.groupLevelRepository.findAll();
+        
+        final GroupLevelDataMapper rm = new GroupLevelDataMapper();
+        final String sql = "select " + rm.groupLevelSchema();
+        return this.jdbcTemplate.query(sql, rm);
+        
     }
+    
+    private static final class GroupLevelDataMapper implements RowMapper<GroupLevelData> {
+
+        public String groupLevelSchema() {
+            return "gl.id as id, gl.level_name as levelName , gl.parent_id as parentLevelId , pgl.level_name as parentName , "
+                    + "cgl.id as childLevelId,cgl.level_name as childLevelName,gl.super_parent as superParent ,"
+                    + " gl.recursable as recursable , gl.can_have_clients as canHaveClients from m_group_level gl "
+                    + " left join m_group_level pgl on pgl.id = gl.parent_id left join m_group_level cgl on gl.id = cgl.parent_id";
+        }
+
+        @Override
+        public GroupLevelData mapRow(final ResultSet rs, @SuppressWarnings("unused") final int rowNum) throws SQLException {
+
+            final Long levelId = rs.getLong("id");
+            final String levelName = rs.getString("levelName");
+            final Long parentLevelId = rs.getLong("parentLevelId");
+            final String parentLevelName = rs.getString("parentName");
+            final Long childLevelId = rs.getLong("childLevelId");
+            final String childLevelName = rs.getString("childLevelName");
+            final boolean superParent = rs.getBoolean("superParent");
+            final boolean recursable = rs.getBoolean("recursable");
+            final boolean canHaveClients = rs.getBoolean("canHaveClients");
+
+            return new GroupLevelData(levelId, levelName, parentLevelId, parentLevelName, childLevelId, childLevelName, superParent,
+                    recursable, canHaveClients);
+        }
+
+    }
+
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/service/GroupReadPlatformServiceImpl.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/service/GroupReadPlatformServiceImpl.java
@@ -338,9 +338,9 @@ public class GroupReadPlatformServiceImpl implements GroupReadPlatformService {
             final Long officeId = rs.getLong("officeId");
             final String officeName = rs.getString("officeName");
             final Long groupLevel = rs.getLong("groupLevel");
-            final Long parentId = rs.getLong("parentId");
+            final Long parentId = JdbcSupport.getLong(rs, "parentId");
             final String parentName = rs.getString("parentName");
-            final Long staffId = rs.getLong("staffId");
+            final Long staffId = JdbcSupport.getLong(rs, "staffId");
             final String staffName = rs.getString("staffName");
             final String hierarchy = rs.getString("hierarchy");
 

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/service/GroupWritePlatformService.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/service/GroupWritePlatformService.java
@@ -7,20 +7,15 @@ package org.mifosplatform.portfolio.group.service;
 
 import org.mifosplatform.infrastructure.core.api.JsonCommand;
 import org.mifosplatform.infrastructure.core.data.CommandProcessingResult;
-import org.springframework.security.access.prepost.PreAuthorize;
 
 public interface GroupWritePlatformService {
 
-    @PreAuthorize(value = "hasAnyRole('ALL_FUNCTIONS', 'CREATE_GROUP')")
     CommandProcessingResult createGroup(JsonCommand command);
 
-    @PreAuthorize(value = "hasAnyRole('ALL_FUNCTIONS', 'UPDATE_GROUP')")
     CommandProcessingResult updateGroup(Long grouptId, JsonCommand command);
 
-    @PreAuthorize(value = "hasAnyRole('ALL_FUNCTIONS', 'DELETE_GROUP')")
     CommandProcessingResult deleteGroup(Long groupId);
 
-    @PreAuthorize(value = "hasAnyRole('ALL_FUNCTIONS', 'UPDATE_GROUP')")
     CommandProcessingResult unassignStaff(Long grouptId, JsonCommand command);
 
 }


### PR DESCRIPTION
Hi Keith,

I have incorporated some of your review comments and status is as below,
- [x] GET /groups - The JSON returned for a 'Center (type of group)' has "parentId": 0, parentId should be null and so parameter wont be returned
- [x] similarly for staffId,  incase of null it was returing 0, corrected
- [ ] GET /groups?fields=id  Should be able to return partial response as I require using fields=xxx approach, a number of fields however are not added as part of support data parameters for response. Where I should only see id I see the following:
- [x] GET /groups?officeId=3 - results in exception and does not work as it does for clients
- [x] GET /groups?name=Cen - returns no results when expected and doent work as it does for clients 
- [x] GET /groups?levelId=3 added levelId as param
- [ ] POST /groups - with empty json request {} results in exception 
  - would expect mandatory fields of 'Group' to be validated (can you please point me to any referance code in the application)
  - staffIdParameterName = "stafftId" misspelt in part of this validation
  - When creating a 'grouping' I would expect to have to pass the details of the 'type of group' [center, JLG-group, village bank etc] but you seem to infer that its either a center or a group (not done yet)
- [x] GroupLevels domain object returned from read side rather than data object like rest of application.
- [x] GroupWritePlatformService - can remove @PreAuthorize security annotations from interface as permissions checked   in command infrastruture

Thanks
Nayan Ambali
