### PR TITLE
MIFOSX-230-1: Extended datatables functionality to Groups and Offices

### DIFF
--- a/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/dataqueries/service/ReadWriteNonCoreDataServiceImpl.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/dataqueries/service/ReadWriteNonCoreDataServiceImpl.java
@@ -362,6 +362,14 @@ public class ReadWriteNonCoreDataServiceImpl implements ReadWriteNonCoreDataServ
             dataScopeCriteria = " join m_client c on c.id = t.client_id " + " join m_office o on o.id = c.office_id and o.hierarchy like '"
                     + currentUser.getOffice().getHierarchy() + "%'";
         }
+         if (appTable.equalsIgnoreCase("m_group")) {
+            dataScopeCriteria = " join m_office o on o.id = t.office_id and o.hierarchy like '"
+                    + currentUser.getOffice().getHierarchy() + "%'";
+        }   
+        if (appTable.equalsIgnoreCase("m_office")) {
+            dataScopeCriteria = " join m_office o on o.id = t.id and o.hierarchy like '"
+                    + currentUser.getOffice().getHierarchy() + "%'";
+        }        
 
         if (dataScopeCriteria == null) { throw new PlatformDataIntegrityException("error.msg.invalid.dataScopeCriteria",
                 "Application Table: " + appTable + " not catered for in data Scoping"); }
@@ -374,6 +382,8 @@ public class ReadWriteNonCoreDataServiceImpl implements ReadWriteNonCoreDataServ
 
         if (appTable.equalsIgnoreCase("m_client")) return;
         if (appTable.equalsIgnoreCase("m_loan")) return;
+        if (appTable.equalsIgnoreCase("m_group")) return;
+        if (appTable.equalsIgnoreCase("m_office")) return;
 
         throw new PlatformDataIntegrityException("error.msg.invalid.application.table", "Invalid Application Table: " + appTable);
     }


### PR DESCRIPTION
For the Musoni Lite implementation I have extended the datatables functionality to the m_group and m_office table.

NOTE For M_office the join of the m_office on m_office table is not the nicest way to allow the correct scoping in WHERE clause instead of JOIN (where replace takes place).
