### PR TITLE
[Sailee/Gurpreet]: Added SSL support for Integration Test

### DIFF
--- a/mifosng-provider/build.gradle
+++ b/mifosng-provider/build.gradle
@@ -236,9 +236,7 @@ task integrationTest(type:Test){
         tomcatRunWar.execute()
     }
 
-    doLast {
-        tomcatStop.execute()
-    }
+
     testClassesDir = project.sourceSets.integrationTest.output.classesDir
     classpath = project.sourceSets.integrationTest.runtimeClasspath
 }

--- a/mifosng-provider/src/integrationTest/java/org/mifosplatform/integrationtests/ClientLoanIntegrationTest.java
+++ b/mifosng-provider/src/integrationTest/java/org/mifosplatform/integrationtests/ClientLoanIntegrationTest.java
@@ -32,6 +32,7 @@ public class ClientLoanIntegrationTest {
 
     @Before
     public void setup() {
+        Utils.initializeRESTAssured();
         requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
         requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
         responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();

--- a/mifosng-provider/src/integrationTest/java/org/mifosplatform/integrationtests/LoanWithWaiveInterestAndWriteOffIntegrationTest.java
+++ b/mifosng-provider/src/integrationTest/java/org/mifosplatform/integrationtests/LoanWithWaiveInterestAndWriteOffIntegrationTest.java
@@ -39,6 +39,7 @@ public class LoanWithWaiveInterestAndWriteOffIntegrationTest {
 
     @Before
     public void setup() {
+        Utils.initializeRESTAssured();
         requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
         requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
         responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
@@ -100,7 +101,7 @@ public class LoanWithWaiveInterestAndWriteOffIntegrationTest {
     private void verifyRepaymentScheduleEntryFor(final int repaymentNumber, final float expectedPrincipalOutstanding, final Integer loanID) {
         System.out.println("---------------------------GETTING LOAN REPAYMENT SCHEDULE--------------------------------");
         ArrayList<HashMap> repaymentPeriods = LoanTransactionHelper.getLoanRepaymentSchedule(requestSpec, responseSpec, loanID);
-        assertEquals(expectedPrincipalOutstanding, repaymentPeriods.get(repaymentNumber).get("principalLoanBalanceOutstanding"));
+        assertEquals("Mismatch in Principal Loan Balance Outstanding ", expectedPrincipalOutstanding, repaymentPeriods.get(repaymentNumber).get("principalLoanBalanceOutstanding"));
     }
 
     private Integer createLoanProduct() {

--- a/mifosng-provider/src/integrationTest/java/org/mifosplatform/integrationtests/common/ClientHelper.java
+++ b/mifosng-provider/src/integrationTest/java/org/mifosplatform/integrationtests/common/ClientHelper.java
@@ -3,11 +3,12 @@ package org.mifosplatform.integrationtests.common;
 import java.util.HashMap;
 import java.util.Random;
 
-import org.junit.Assert;
 
 import com.google.gson.Gson;
 import com.jayway.restassured.specification.RequestSpecification;
 import com.jayway.restassured.specification.ResponseSpecification;
+
+import static org.junit.Assert.assertEquals;
 
 public class ClientHelper {
 
@@ -41,7 +42,7 @@ public class ClientHelper {
         System.out.println("------------------------------CHECK CLIENT DETAILS------------------------------------\n");
         String CLIENT_URL = "/mifosng-provider/api/v1/clients/" + generatedClientID + "?tenantIdentifier=default";
         Integer responseClientID = Utils.performServerGet(requestSpec, responseSpec, CLIENT_URL, "id");
-        Assert.assertEquals(generatedClientID, responseClientID);
+        assertEquals("ERROR IN CREATING THE CLIENT",generatedClientID, responseClientID);
     }
 
     private static String randomStringGenerator(final String prefix, final int len, final String sourceSetString) {

--- a/mifosng-provider/src/integrationTest/java/org/mifosplatform/integrationtests/common/Utils.java
+++ b/mifosng-provider/src/integrationTest/java/org/mifosplatform/integrationtests/common/Utils.java
@@ -2,7 +2,9 @@ package org.mifosplatform.integrationtests.common;
 
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.path.json.JsonPath.from;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.fail;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.conn.HttpHostConnectException;
@@ -17,21 +19,24 @@ public class Utils {
 
     private static final String LOGIN_URL = "/mifosng-provider/api/v1/authentication?username=mifos&password=password&tenantIdentifier=default";
 
+
+    public static void initializeRESTAssured() {
+        RestAssured.baseURI ="https://localhost";
+        RestAssured.port = 8443;
+        RestAssured.keystore("../keystore.jks", "openmf");
+    }
+
     public static String loginIntoServerAndGetBase64EncodedAuthenticationKey() {
         try {
             System.out.println("-----------------------------------LOGIN-----------------------------------------");
             String json = RestAssured.post(LOGIN_URL).asString();
-            if (StringUtils.isBlank(json)) {
-                assertThat(
-                        "Failed to login into mifosx platform: Please check it is running and you have changed its securityContext.xml from requires-channel=\"https\" to requires-channel=\"http\"",
-                        false);
-            }
+            assertThat("Failed to login into mifosx platform",StringUtils.isBlank(json),is(false));
             return JsonPath.with(json).get("base64EncodedAuthenticationKey");
-        } catch (Exception e) {
-
+        }
+        catch (Exception e) {
             if (e instanceof HttpHostConnectException) {
                 HttpHostConnectException hh = (HttpHostConnectException) e;
-                assertThat("Failed to connect to mifosx platform: " + hh.getMessage(), false);
+                fail("Failed to connect to mifosx platform:"+hh.getMessage());
             }
 
             throw new RuntimeException(e);


### PR DESCRIPTION
Now the integrationTests will run in HTTPs mode. Just run "gradle integrationTest" and it will run it including running tomcat. 
