### PR TITLE
handling rename of TenantUpgradeService to TenantDatabaseUpgradeService

### DIFF
--- a/mifosng-provider/src/main/resources/META-INF/spring/infrastructure.xml
+++ b/mifosng-provider/src/main/resources/META-INF/spring/infrastructure.xml
@@ -13,7 +13,7 @@
     	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
     	http://www.springframework.org/schema/jee http://www.springframework.org/schema/jee/spring-jee-3.0.xsd">
 
-    <bean id="entityManagerFactory" class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean" depends-on="tenantUpgradeService">
+    <bean id="entityManagerFactory" class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean" depends-on="tenantDatabaseUpgradeService">
         <property name="dataSource" ref="tenantAwareDataSource" />
         <property name="persistenceUnitName" value="jpa-pu" />
         <property name="jpaVendorAdapter">


### PR DESCRIPTION
Since Flyway must run before Hiberante related classes are loaded, tenantDatabaseUpgradeService is set as dependency for entityManager (so any rename of this bean would have to be updated in xml too. )
