### PR TITLE
MIFOSX-282: remove min and max fields from loan table

### DIFF
--- a/mifosng-db/migrations/core_db/V16__drop_min_max_column_on_loan_table.sql
+++ b/mifosng-db/migrations/core_db/V16__drop_min_max_column_on_loan_table.sql
@@ -1,0 +1,7 @@
+ALTER TABLE `m_loan`
+	DROP COLUMN `min_principal_amount`,
+	DROP COLUMN `max_principal_amount`,
+	DROP COLUMN `min_nominal_interest_rate_per_period`,
+	DROP COLUMN `max_nominal_interest_rate_per_period`,
+	DROP COLUMN `min_number_of_repayments`,
+	DROP COLUMN `max_number_of_repayments`;

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/domain/Loan.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/domain/Loan.java
@@ -668,6 +668,10 @@ public class Loan extends AbstractPersistable<Long> {
         return this.client;
     }
 
+    public LoanProduct loanProduct(){
+        return this.loanProduct;
+    }
+    
     public LoanProductRelatedDetail repaymentScheduleDetail() {
         return this.loanRepaymentScheduleDetail;
     }
@@ -1318,12 +1322,8 @@ public class Loan extends AbstractPersistable<Long> {
         final LoanScheduleGenerator loanScheduleGenerator = new DefaultLoanScheduleGeneratorFactory().create(interestMethod);
 
         final BigDecimal principal = this.loanRepaymentScheduleDetail.getPrincipal().getAmount();
-        final BigDecimal minPrincipal = this.loanRepaymentScheduleDetail.getMinPrincipal().getAmount();
-        final BigDecimal maxPrincipal = this.loanRepaymentScheduleDetail.getMaxPrincipal().getAmount();
         final BigDecimal inArrearsTolerance = this.loanRepaymentScheduleDetail.getInArrearsTolerance().getAmount();
         final BigDecimal interestRatePerPeriod = this.loanRepaymentScheduleDetail.getNominalInterestRatePerPeriod();
-        final BigDecimal minInterestRatePerPeriod = this.loanRepaymentScheduleDetail.getMinNominalInterestRatePerPeriod();
-        final BigDecimal maxInterestRatePerPeriod = this.loanRepaymentScheduleDetail.getMaxNominalInterestRatePerPeriod();
         final PeriodFrequencyType interestRatePeriodFrequencyType = this.loanRepaymentScheduleDetail.getInterestPeriodFrequencyType();
         final BigDecimal defaultAnnualNominalInterestRate = this.loanRepaymentScheduleDetail.getAnnualNominalInterestRate();
 
@@ -1332,18 +1332,15 @@ public class Loan extends AbstractPersistable<Long> {
         final Integer repaymentEvery = this.loanRepaymentScheduleDetail.getRepayEvery();
         final PeriodFrequencyType repaymentPeriodFrequencyType = this.loanRepaymentScheduleDetail.getRepaymentPeriodFrequencyType();
         final Integer numberOfRepayments = this.loanRepaymentScheduleDetail.getNumberOfRepayments();
-        final Integer minNumberOfRepayments = this.loanRepaymentScheduleDetail.getMinNumberOfRepayments();
-        final Integer maxNumberOfRepayments = this.loanRepaymentScheduleDetail.getMaxNumberOfRepayments();
         final AmortizationMethod amortizationMethod = this.loanRepaymentScheduleDetail.getAmortizationMethod();
         final Integer loanTermFrequency = this.termFrequency;
         final PeriodFrequencyType loanTermPeriodFrequencyType = PeriodFrequencyType.fromInt(this.termPeriodFrequencyType);
 
-        final LoanSchedule loanSchedule = new LoanSchedule(loanScheduleGenerator, applicationCurrency, principal, minPrincipal,
-                maxPrincipal, interestRatePerPeriod, minInterestRatePerPeriod, maxInterestRatePerPeriod, interestRatePeriodFrequencyType,
-                defaultAnnualNominalInterestRate, interestMethod, interestCalculationPeriodMethod, repaymentEvery,
-                repaymentPeriodFrequencyType, numberOfRepayments, minNumberOfRepayments, maxNumberOfRepayments, amortizationMethod,
-                loanTermFrequency, loanTermPeriodFrequencyType, setOfLoanCharges(), this.getDisbursementDate(),
-                this.getExpectedFirstRepaymentOnDate(), this.getInterestChargedFromDate(), inArrearsTolerance);
+        final LoanSchedule loanSchedule = new LoanSchedule(loanScheduleGenerator, applicationCurrency, principal, interestRatePerPeriod,
+                interestRatePeriodFrequencyType, defaultAnnualNominalInterestRate, interestMethod, interestCalculationPeriodMethod,
+                repaymentEvery, repaymentPeriodFrequencyType, numberOfRepayments, amortizationMethod, loanTermFrequency,
+                loanTermPeriodFrequencyType, setOfLoanCharges(), this.getDisbursementDate(), this.getExpectedFirstRepaymentOnDate(),
+                this.getInterestChargedFromDate(), inArrearsTolerance);
 
         final LoanScheduleData generatedData = loanSchedule.generate();
 

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/loanschedule/domain/LoanSchedule.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/loanschedule/domain/LoanSchedule.java
@@ -27,11 +27,7 @@ public final class LoanSchedule {
     private final LoanScheduleGenerator loanScheduleGenerator;
     private final ApplicationCurrency applicationCurrency;
     private final BigDecimal principal;
-    private final BigDecimal minPrincipal;
-    private final BigDecimal maxPrincipal;
     private final BigDecimal nominalInterestRatePerPeriod;
-    private final BigDecimal minNominalInterestRatePerPeriod;
-    private final BigDecimal maxNominalInterestRatePerPeriod;
     private final PeriodFrequencyType interestRatePeriodFrequencyType;
     private final BigDecimal nominalAnnualInterestRate;
     private final InterestMethod interestMethod;
@@ -39,8 +35,6 @@ public final class LoanSchedule {
     private final Integer repaymentEvery;
     private final PeriodFrequencyType repaymentPeriodFrequencyType;
     private final Integer numberOfRepayments;
-    private final Integer minNumberOfRepayments;
-    private final Integer maxNumberOfRepayments;
     private final AmortizationMethod amortizationMethod;
     private final Integer loanTermFrequency;
     private final PeriodFrequencyType loanTermPeriodFrequencyType;
@@ -52,22 +46,17 @@ public final class LoanSchedule {
     private final Set<LoanCharge> loanCharges;
 
     public LoanSchedule(final LoanScheduleGenerator loanScheduleGenerator, final ApplicationCurrency applicationCurrency,
-            final BigDecimal principal, final BigDecimal minPrincipal, final BigDecimal maxPrincipal,
-            final BigDecimal nominalInterestRatePerPeriod, final BigDecimal minNominalInterestRatePerPeriod, final BigDecimal maxNominalInterestRatePerPeriod, final PeriodFrequencyType interestRatePeriodFrequencyType,
-            final BigDecimal nominalAnnualInterestRate, final InterestMethod interestMethod,
-            final InterestCalculationPeriodMethod interestCalculationPeriodMethod, final Integer repaymentEvery,
-            final PeriodFrequencyType repaymentPeriodFrequencyType, final Integer numberOfRepayments, final Integer minNumberOfRepayments, final Integer maxNumberOfRepayments,
+            final BigDecimal principal, final BigDecimal nominalInterestRatePerPeriod,
+            final PeriodFrequencyType interestRatePeriodFrequencyType, final BigDecimal nominalAnnualInterestRate,
+            final InterestMethod interestMethod, final InterestCalculationPeriodMethod interestCalculationPeriodMethod,
+            final Integer repaymentEvery, final PeriodFrequencyType repaymentPeriodFrequencyType, final Integer numberOfRepayments,
             final AmortizationMethod amortizationMethod, final Integer loanTermFrequency,
             final PeriodFrequencyType loanTermPeriodFrequencyType, final Set<LoanCharge> loanCharges, final LocalDate disbursementDate,
             final LocalDate repaymentStartFromDate, final LocalDate interestChargedFromDate, final BigDecimal inArrearsTolerance) {
         this.loanScheduleGenerator = loanScheduleGenerator;
         this.applicationCurrency = applicationCurrency;
         this.principal = principal;
-        this.minPrincipal = minPrincipal;
-        this.maxPrincipal = maxPrincipal;
         this.nominalInterestRatePerPeriod = nominalInterestRatePerPeriod;
-        this.minNominalInterestRatePerPeriod = minNominalInterestRatePerPeriod;
-        this.maxNominalInterestRatePerPeriod = maxNominalInterestRatePerPeriod;
         this.interestRatePeriodFrequencyType = interestRatePeriodFrequencyType;
         this.nominalAnnualInterestRate = nominalAnnualInterestRate;
         this.interestMethod = interestMethod;
@@ -75,8 +64,6 @@ public final class LoanSchedule {
         this.repaymentEvery = repaymentEvery;
         this.repaymentPeriodFrequencyType = repaymentPeriodFrequencyType;
         this.numberOfRepayments = numberOfRepayments;
-        this.minNumberOfRepayments = minNumberOfRepayments;
-        this.maxNumberOfRepayments = maxNumberOfRepayments;
         this.amortizationMethod = amortizationMethod;
         this.loanTermFrequency = loanTermFrequency;
         this.loanTermPeriodFrequencyType = loanTermPeriodFrequencyType;
@@ -95,9 +82,9 @@ public final class LoanSchedule {
     public LoanProductRelatedDetail loanProductRelatedDetail() {
         final MonetaryCurrency currency = new MonetaryCurrency(applicationCurrency.getCode(), applicationCurrency.getDecimalPlaces());
 
-        return LoanProductRelatedDetail.createFrom(currency, principal, minPrincipal, maxPrincipal, nominalInterestRatePerPeriod, minNominalInterestRatePerPeriod, maxNominalInterestRatePerPeriod,
-                interestRatePeriodFrequencyType, nominalAnnualInterestRate, interestMethod, interestCalculationPeriodMethod,
-                repaymentEvery, repaymentPeriodFrequencyType, numberOfRepayments, minNumberOfRepayments, maxNumberOfRepayments, amortizationMethod, this.inArrearsTolerance);
+        return LoanProductRelatedDetail.createFrom(currency, principal, nominalInterestRatePerPeriod, interestRatePeriodFrequencyType,
+                nominalAnnualInterestRate, interestMethod, interestCalculationPeriodMethod, repaymentEvery, repaymentPeriodFrequencyType,
+                numberOfRepayments, amortizationMethod, this.inArrearsTolerance);
     }
 
     public Integer getLoanTermFrequency() {

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/loanschedule/service/LoanScheduleAssembler.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/loanschedule/service/LoanScheduleAssembler.java
@@ -73,33 +73,7 @@ public class LoanScheduleAssembler {
         final ApplicationCurrency applicationCurrency = this.applicationCurrencyRepository.findOneWithNotFoundDetection(currency);
 
         final BigDecimal principal = fromApiJsonHelper.extractBigDecimalWithLocaleNamed("principal", element);
-        final BigDecimal minPrincipal = loanProduct.getMinPrincipalAmount().getAmount();// Copy
-                                                                                        // minPrincipal
-                                                                                        // from
-                                                                                        // loan
-                                                                                        // product
-                                                                                        // to
-                                                                                        // loan
-        final BigDecimal maxPrincipal = loanProduct.getMaxPrincipalAmount().getAmount();// Copy
-                                                                                        // maxPrincipal
-                                                                                        // from
-                                                                                        // loan
-                                                                                        // product
-                                                                                        // to
-                                                                                        // loan
         final BigDecimal interestRatePerPeriod = fromApiJsonHelper.extractBigDecimalWithLocaleNamed("interestRatePerPeriod", element);
-        final BigDecimal minInterestRatePerPeriod = loanProduct.getMinNominalInterestRatePerPeriod();// Copy
-                                                                                                     // from
-                                                                                                     // Loan
-                                                                                                     // product
-                                                                                                     // to
-                                                                                                     // Loan
-        final BigDecimal maxInterestRatePerPeriod = loanProduct.getMaxNominalInterestRatePerPeriod();// Copy
-                                                                                                     // from
-                                                                                                     // Loan
-                                                                                                     // product
-                                                                                                     // to
-                                                                                                     // Loan
         final Integer interestRateFrequencyType = fromApiJsonHelper.extractIntegerWithLocaleNamed("interestRateFrequencyType", element);
         final Integer interestType = fromApiJsonHelper.extractIntegerWithLocaleNamed("interestType", element);
         final Integer interestCalculationPeriodType = fromApiJsonHelper.extractIntegerWithLocaleNamed("interestCalculationPeriodType",
@@ -116,18 +90,6 @@ public class LoanScheduleAssembler {
         final Integer repaymentEvery = fromApiJsonHelper.extractIntegerWithLocaleNamed("repaymentEvery", element);
         final Integer repaymentFrequencyType = fromApiJsonHelper.extractIntegerWithLocaleNamed("repaymentFrequencyType", element);
         final Integer numberOfRepayments = fromApiJsonHelper.extractIntegerWithLocaleNamed("numberOfRepayments", element);
-        final Integer minNumberOfRepayments = loanProduct.getMinNumberOfRepayments();// Copy
-                                                                                     // from
-                                                                                     // Loan
-                                                                                     // product
-                                                                                     // to
-                                                                                     // Loan
-        final Integer maxNumberOfRepayments = loanProduct.getMaxNumberOfRepayments();// Copy
-                                                                                     // from
-                                                                                     // Loan
-                                                                                     // product
-                                                                                     // to
-                                                                                     // Loan
         final Integer amortizationType = fromApiJsonHelper.extractIntegerWithLocaleNamed("amortizationType", element);
         final PeriodFrequencyType repaymentPeriodFrequencyType = PeriodFrequencyType.fromInt(repaymentFrequencyType);
         final AmortizationMethod amortizationMethod = AmortizationMethod.fromInt(amortizationType);
@@ -144,10 +106,10 @@ public class LoanScheduleAssembler {
 
         final LoanScheduleGenerator loanScheduleGenerator = this.loanScheduleFactory.create(interestMethod);
 
-        return new LoanSchedule(loanScheduleGenerator, applicationCurrency, principal, minPrincipal, maxPrincipal, interestRatePerPeriod,
-                minInterestRatePerPeriod, maxInterestRatePerPeriod, interestRatePeriodFrequencyType, defaultAnnualNominalInterestRate,
-                interestMethod, interestCalculationPeriodMethod, repaymentEvery, repaymentPeriodFrequencyType, numberOfRepayments,
-                minNumberOfRepayments, maxNumberOfRepayments, amortizationMethod, loanTermFrequency, loanTermPeriodFrequencyType,
-                loanCharges, expectedDisbursementDate, repaymentsStartingFromDate, interestChargedFromDate, inArrearsTolerance);
+        return new LoanSchedule(loanScheduleGenerator, applicationCurrency, principal, interestRatePerPeriod,
+                interestRatePeriodFrequencyType, defaultAnnualNominalInterestRate, interestMethod, interestCalculationPeriodMethod,
+                repaymentEvery, repaymentPeriodFrequencyType, numberOfRepayments, amortizationMethod, loanTermFrequency,
+                loanTermPeriodFrequencyType, loanCharges, expectedDisbursementDate, repaymentsStartingFromDate, interestChargedFromDate,
+                inArrearsTolerance);
     }
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/serialization/LoanApplicationCommandFromApiJsonHelper.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/serialization/LoanApplicationCommandFromApiJsonHelper.java
@@ -23,6 +23,7 @@ import org.mifosplatform.infrastructure.core.exception.InvalidJsonException;
 import org.mifosplatform.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.mifosplatform.infrastructure.core.serialization.FromJsonHelper;
 import org.mifosplatform.portfolio.loanproduct.domain.LoanProduct;
+import org.mifosplatform.portfolio.loanproduct.serialization.LoanProductCommandFromApiJsonDeserializer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -49,13 +50,16 @@ public final class LoanApplicationCommandFromApiJsonHelper {
     ));
 
     private final FromJsonHelper fromApiJsonHelper;
+    
+    private final LoanProductCommandFromApiJsonDeserializer loanProductCommandFromApiJsonDeserializer;
 
     @Autowired
-    public LoanApplicationCommandFromApiJsonHelper(final FromJsonHelper fromApiJsonHelper) {
+    public LoanApplicationCommandFromApiJsonHelper(final FromJsonHelper fromApiJsonHelper, final LoanProductCommandFromApiJsonDeserializer loanProductCommandFromApiJsonDeserializer) {
         this.fromApiJsonHelper = fromApiJsonHelper;
+        this.loanProductCommandFromApiJsonDeserializer = loanProductCommandFromApiJsonDeserializer;
     }
 
-    public void validateForCreate(final String json) {
+    public void validateForCreate(final String json, final LoanProduct loanProduct) {
         if (StringUtils.isBlank(json)) { throw new InvalidJsonException(); }
 
         final Type typeOfMap = new TypeToken<Map<String, Object>>() {}.getType();
@@ -281,6 +285,8 @@ public final class LoanApplicationCommandFromApiJsonHelper {
             }
         }
 
+        loanProductCommandFromApiJsonDeserializer.validateMinMaxConstraints(element, baseDataValidator, loanProduct);
+        
         if (!dataValidationErrors.isEmpty()) { throw new PlatformApiDataValidationException("validation.msg.validation.errors.exist",
                 "Validation errors exist.", dataValidationErrors); }
     }
@@ -593,19 +599,11 @@ public final class LoanApplicationCommandFromApiJsonHelper {
                 "Validation errors exist.", dataValidationErrors); }
     }
     
-    public void validateMinMaxConstraintValues(final JsonElement element, final LoanProduct loanProduct){
-
+    public void validateMinMaxConstraintsForModification(final String json, final LoanProduct loanProduct) {
+        final JsonElement element = fromApiJsonHelper.parse(json);
         final List<ApiParameterError> dataValidationErrors = new ArrayList<ApiParameterError>();
         final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors).resource("loan");
-        
-        final BigDecimal minPrincipal = loanProduct.getMinPrincipalAmount().getAmount();
-        final BigDecimal maxPrincipal = loanProduct.getMaxPrincipalAmount().getAmount();
-        final String principalParameterName = "principal";
-
-        if (fromApiJsonHelper.parameterExists(principalParameterName, element)) {
-            final BigDecimal principal = fromApiJsonHelper.extractBigDecimalWithLocaleNamed(principalParameterName, element);
-            baseDataValidator.reset().parameter(principalParameterName).value(principal).notNull().positiveAmount().inMinAndMaxAmountRange(minPrincipal, maxPrincipal);
-        }
+        this.loanProductCommandFromApiJsonDeserializer.validateMinMaxConstraints(element, baseDataValidator, loanProduct);
         if (!dataValidationErrors.isEmpty()) { throw new PlatformApiDataValidationException("validation.msg.validation.errors.exist",
                 "Validation errors exist.", dataValidationErrors); }
     }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/service/LoanAssembler.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/service/LoanAssembler.java
@@ -46,7 +46,6 @@ import org.mifosplatform.portfolio.loanproduct.domain.LoanProduct;
 import org.mifosplatform.portfolio.loanproduct.domain.LoanProductRepository;
 import org.mifosplatform.portfolio.loanproduct.domain.LoanTransactionProcessingStrategy;
 import org.mifosplatform.portfolio.loanproduct.exception.LoanProductNotFoundException;
-import org.mifosplatform.portfolio.loanproduct.serialization.LoanProductCommandFromApiJsonDeserializer;
 import org.mifosplatform.useradministration.domain.AppUser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -69,7 +68,6 @@ public class LoanAssembler {
     private final FromJsonHelper fromApiJsonHelper;
     private final LoanSummaryWrapper loanSummaryWrapper;
     private final LoanRepaymentScheduleTransactionProcessorFactory loanRepaymentScheduleTransactionProcessorFactory;
-    private final LoanProductCommandFromApiJsonDeserializer loanProductCommandFromApiJsonDeserializer;
 
     @Autowired
     public LoanAssembler(final FromJsonHelper fromApiJsonHelper, final LoanProductRepository loanProductRepository,
@@ -78,8 +76,7 @@ public class LoanAssembler {
             final StaffRepository staffRepository, final CodeValueRepositoryWrapper codeValueRepository,
             final LoanScheduleAssembler loanScheduleAssembler, final LoanChargeAssembler loanChargeAssembler,
             final CollateralAssembler loanCollateralAssembler, final LoanSummaryWrapper loanSummaryWrapper,
-            final LoanRepaymentScheduleTransactionProcessorFactory loanRepaymentScheduleTransactionProcessorFactory,
-            final LoanProductCommandFromApiJsonDeserializer loanProductCommandFromApiJsonDeserializer) {
+            final LoanRepaymentScheduleTransactionProcessorFactory loanRepaymentScheduleTransactionProcessorFactory) {
         this.fromApiJsonHelper = fromApiJsonHelper;
         this.loanProductRepository = loanProductRepository;
         this.clientRepository = clientRepository;
@@ -93,7 +90,6 @@ public class LoanAssembler {
         this.loanCollateralAssembler = loanCollateralAssembler;
         this.loanSummaryWrapper = loanSummaryWrapper;
         this.loanRepaymentScheduleTransactionProcessorFactory = loanRepaymentScheduleTransactionProcessorFactory;
-        this.loanProductCommandFromApiJsonDeserializer = loanProductCommandFromApiJsonDeserializer;
     }
 
     public Loan assembleFrom(final JsonCommand command, final AppUser currentUser) {
@@ -116,9 +112,6 @@ public class LoanAssembler {
 
         final LoanProduct loanProduct = this.loanProductRepository.findOne(productId);
         if (loanProduct == null) { throw new LoanProductNotFoundException(productId); }
-
-        //validate min and max constraint parameters
-        this.loanProductCommandFromApiJsonDeserializer.validateMinMaxConstraints(element, loanProduct.loanProductRelatedDetail(), "loan");
         
         final Fund fund = findFundByIdIfProvided(fundId);
         final Staff loanOfficer = findLoanOfficerByIdIfProvided(loanOfficerId);

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanproduct/domain/LoanProductMinMaxConstraints.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanproduct/domain/LoanProductMinMaxConstraints.java
@@ -1,0 +1,150 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.mifosplatform.portfolio.loanproduct.domain;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+import org.mifosplatform.infrastructure.core.api.JsonCommand;
+
+/**
+ * LoanProductMinMaxConstraints encapsulates all the Min and Max details of a
+ * {@link LoanProduct}.
+ */
+@Embeddable
+public class LoanProductMinMaxConstraints {
+
+    @Column(name = "min_principal_amount", scale = 6, precision = 19, nullable = true)
+    private BigDecimal minPrincipal;
+
+    @Column(name = "max_principal_amount", scale = 6, precision = 19, nullable = true)
+    private BigDecimal maxPrincipal;
+
+    @Column(name = "min_nominal_interest_rate_per_period", scale = 6, precision = 19, nullable = true)
+    private BigDecimal minNominalInterestRatePerPeriod;
+
+    @Column(name = "max_nominal_interest_rate_per_period", scale = 6, precision = 19, nullable = true)
+    private BigDecimal maxNominalInterestRatePerPeriod;
+
+    @Column(name = "min_number_of_repayments", nullable = true)
+    private Integer minNumberOfRepayments;
+
+    @Column(name = "max_number_of_repayments", nullable = true)
+    private Integer maxNumberOfRepayments;
+
+    public static LoanProductMinMaxConstraints createFrom(final BigDecimal minPrincipal, final BigDecimal maxPrincipal,
+            final BigDecimal minNominalInterestRatePerPeriod, final BigDecimal maxNominalInterestRatePerPeriod,
+            final Integer minNumberOfRepayments, final Integer maxNumberOfRepayments) {
+
+        return new LoanProductMinMaxConstraints(minPrincipal, maxPrincipal, minNominalInterestRatePerPeriod,
+                maxNominalInterestRatePerPeriod, minNumberOfRepayments, maxNumberOfRepayments);
+    }
+
+    protected LoanProductMinMaxConstraints() {
+        //
+    }
+
+    public LoanProductMinMaxConstraints(final BigDecimal defaultMinPrincipal, final BigDecimal defaultMaxPrincipal,
+            final BigDecimal defaultMinNominalInterestRatePerPeriod, final BigDecimal defaultMaxNominalInterestRatePerPeriod,
+            final Integer defaultMinNumberOfRepayments, final Integer defaultMaxNumberOfRepayments) {
+        this.minPrincipal = defaultMinPrincipal;
+        this.maxPrincipal = defaultMaxPrincipal;
+        this.minNominalInterestRatePerPeriod = defaultMinNominalInterestRatePerPeriod;
+        this.maxNominalInterestRatePerPeriod = defaultMaxNominalInterestRatePerPeriod;
+        this.minNumberOfRepayments = defaultMinNumberOfRepayments;
+        this.maxNumberOfRepayments = defaultMaxNumberOfRepayments;
+    }
+
+    public Map<String, Object> update(final JsonCommand command) {
+
+        final Map<String, Object> actualChanges = new LinkedHashMap<String, Object>(20);
+
+        final String localeAsInput = command.locale();
+
+        final String minPrincipalParamName = "minPrincipal";
+        if (command.isChangeInBigDecimalParameterNamedWithNullCheck(minPrincipalParamName, this.minPrincipal)) {
+            final BigDecimal newValue = command.bigDecimalValueOfParameterNamed(minPrincipalParamName);
+            actualChanges.put(minPrincipalParamName, newValue);
+            actualChanges.put("locale", localeAsInput);
+            this.minPrincipal = newValue;
+        }
+
+        final String maxPrincipalParamName = "maxPrincipal";
+        if (command.isChangeInBigDecimalParameterNamedWithNullCheck(maxPrincipalParamName, this.maxPrincipal)) {
+            final BigDecimal newValue = command.bigDecimalValueOfParameterNamed(maxPrincipalParamName);
+            actualChanges.put(maxPrincipalParamName, newValue);
+            actualChanges.put("locale", localeAsInput);
+            this.maxPrincipal = newValue;
+        }
+
+        final String minNumberOfRepaymentsParamName = "minNumberOfRepayments";
+        if (command.isChangeInIntegerParameterNamed(minNumberOfRepaymentsParamName, this.minNumberOfRepayments)) {
+            final Integer newValue = command.integerValueOfParameterNamed(minNumberOfRepaymentsParamName);
+            actualChanges.put(minNumberOfRepaymentsParamName, newValue);
+            actualChanges.put("locale", localeAsInput);
+            this.minNumberOfRepayments = newValue;
+        }
+
+        final String maxNumberOfRepaymentsParamName = "maxNumberOfRepayments";
+        if (command.isChangeInIntegerParameterNamed(maxNumberOfRepaymentsParamName, this.maxNumberOfRepayments)) {
+            final Integer newValue = command.integerValueOfParameterNamed(maxNumberOfRepaymentsParamName);
+            actualChanges.put(maxNumberOfRepaymentsParamName, newValue);
+            actualChanges.put("locale", localeAsInput);
+            this.maxNumberOfRepayments = newValue;
+        }
+
+        final String minInterestRatePerPeriodParamName = "minInterestRatePerPeriod";
+        if (command
+                .isChangeInBigDecimalParameterNamedWithNullCheck(minInterestRatePerPeriodParamName, this.minNominalInterestRatePerPeriod)) {
+            final BigDecimal newValue = command.bigDecimalValueOfParameterNamed(minInterestRatePerPeriodParamName);
+            actualChanges.put(minInterestRatePerPeriodParamName, newValue);
+            actualChanges.put("locale", localeAsInput);
+            this.minNominalInterestRatePerPeriod = newValue;
+        }
+
+        final String maxInterestRatePerPeriodParamName = "maxInterestRatePerPeriod";
+        if (command
+                .isChangeInBigDecimalParameterNamedWithNullCheck(maxInterestRatePerPeriodParamName, this.maxNominalInterestRatePerPeriod)) {
+            final BigDecimal newValue = command.bigDecimalValueOfParameterNamed(maxInterestRatePerPeriodParamName);
+            actualChanges.put(maxInterestRatePerPeriodParamName, newValue);
+            actualChanges.put("locale", localeAsInput);
+            this.maxNominalInterestRatePerPeriod = newValue;
+        }
+
+        return actualChanges;
+    }
+    
+    public BigDecimal getMinPrincipal() {
+        return this.minPrincipal;
+    }
+    
+    public BigDecimal getMaxPrincipal() {
+        return this.maxPrincipal;
+    }
+
+    public BigDecimal getMinNominalInterestRatePerPeriod() {
+        return this.minNominalInterestRatePerPeriod == null ? null : BigDecimal.valueOf(Double.valueOf(this.minNominalInterestRatePerPeriod
+                .stripTrailingZeros().toString()));
+    }
+
+    public BigDecimal getMaxNominalInterestRatePerPeriod() {
+        return this.maxNominalInterestRatePerPeriod == null ? null : BigDecimal.valueOf(Double.valueOf(this.maxNominalInterestRatePerPeriod
+                .stripTrailingZeros().toString()));
+    }
+
+    public Integer getMinNumberOfRepayments() {
+        return minNumberOfRepayments;
+    }
+
+    public Integer getMaxNumberOfRepayments() {
+        return maxNumberOfRepayments;
+    }
+
+}

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanproduct/domain/LoanProductRelatedDetail.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanproduct/domain/LoanProductRelatedDetail.java
@@ -34,20 +34,8 @@ public class LoanProductRelatedDetail implements LoanProductMinimumRepaymentSche
     @Column(name = "principal_amount", scale = 6, precision = 19, nullable = false)
     private BigDecimal principal;
     
-    @Column(name = "min_principal_amount", scale = 6, precision = 19, nullable = true)
-    private BigDecimal minPrincipal;
-    
-    @Column(name = "max_principal_amount", scale = 6, precision = 19, nullable = true)
-    private BigDecimal maxPrincipal;
-
     @Column(name = "nominal_interest_rate_per_period", scale = 6, precision = 19, nullable = false)
     private BigDecimal nominalInterestRatePerPeriod;
-    
-    @Column(name = "min_nominal_interest_rate_per_period", scale = 6, precision = 19, nullable = true)
-    private BigDecimal minNominalInterestRatePerPeriod;
-    
-    @Column(name = "max_nominal_interest_rate_per_period", scale = 6, precision = 19, nullable = true)
-    private BigDecimal maxNominalInterestRatePerPeriod;
 
     // FIXME - move away form JPA ordinal use for enums using just integer -
     // requires sql patch for existing users of software.
@@ -81,12 +69,6 @@ public class LoanProductRelatedDetail implements LoanProductMinimumRepaymentSche
 
     @Column(name = "number_of_repayments", nullable = false)
     private Integer numberOfRepayments;
-
-    @Column(name = "min_number_of_repayments", nullable = true)
-    private Integer minNumberOfRepayments;
-    
-    @Column(name = "max_number_of_repayments", nullable = true)
-    private Integer maxNumberOfRepayments;
     
     // FIXME - move away form JPA ordinal use for enums using just integer -
     // requires sql patch for existing users of software.
@@ -98,18 +80,15 @@ public class LoanProductRelatedDetail implements LoanProductMinimumRepaymentSche
     private BigDecimal inArrearsTolerance;
 
     public static LoanProductRelatedDetail createFrom(final MonetaryCurrency currency, final BigDecimal principal,
-            final BigDecimal minPrincipal, final BigDecimal maxPrincipal, final BigDecimal nominalInterestRatePerPeriod,
-            final BigDecimal minNominalInterestRatePerPeriod, final BigDecimal maxNominalInterestRatePerPeriod,
-            final PeriodFrequencyType interestRatePeriodFrequencyType, final BigDecimal nominalAnnualInterestRate,
-            final InterestMethod interestMethod, final InterestCalculationPeriodMethod interestCalculationPeriodMethod,
-            final Integer repaymentEvery, final PeriodFrequencyType repaymentPeriodFrequencyType, final Integer numberOfRepayments,
-            final Integer minNumberOfRepayments, final Integer maxNumberOfRepayments, final AmortizationMethod amortizationMethod,
-            final BigDecimal inArrearsTolerance) {
+            final BigDecimal nominalInterestRatePerPeriod, final PeriodFrequencyType interestRatePeriodFrequencyType,
+            final BigDecimal nominalAnnualInterestRate, final InterestMethod interestMethod,
+            final InterestCalculationPeriodMethod interestCalculationPeriodMethod, final Integer repaymentEvery,
+            final PeriodFrequencyType repaymentPeriodFrequencyType, final Integer numberOfRepayments,
+            final AmortizationMethod amortizationMethod, final BigDecimal inArrearsTolerance) {
 
-        return new LoanProductRelatedDetail(currency, principal, minPrincipal, maxPrincipal, nominalInterestRatePerPeriod,
-                minNominalInterestRatePerPeriod, maxNominalInterestRatePerPeriod, interestRatePeriodFrequencyType,
+        return new LoanProductRelatedDetail(currency, principal, nominalInterestRatePerPeriod, interestRatePeriodFrequencyType,
                 nominalAnnualInterestRate, interestMethod, interestCalculationPeriodMethod, repaymentEvery, repaymentPeriodFrequencyType,
-                numberOfRepayments, minNumberOfRepayments, maxNumberOfRepayments, amortizationMethod, inArrearsTolerance);
+                numberOfRepayments, amortizationMethod, inArrearsTolerance);
     }
 
     protected LoanProductRelatedDetail() {
@@ -117,21 +96,14 @@ public class LoanProductRelatedDetail implements LoanProductMinimumRepaymentSche
     }
 
     public LoanProductRelatedDetail(final MonetaryCurrency currency, final BigDecimal defaultPrincipal,
-            final BigDecimal defaultMinPrincipal, final BigDecimal defaultMaxPrincipal,
-            final BigDecimal defaultNominalInterestRatePerPeriod, final BigDecimal defaultMinNominalInterestRatePerPeriod,
-            final BigDecimal defaultMaxNominalInterestRatePerPeriod, final PeriodFrequencyType interestPeriodFrequencyType,
+            final BigDecimal defaultNominalInterestRatePerPeriod,final PeriodFrequencyType interestPeriodFrequencyType,
             final BigDecimal defaultAnnualNominalInterestRate, final InterestMethod interestMethod,
             final InterestCalculationPeriodMethod interestCalculationPeriodMethod, final Integer repayEvery,
             final PeriodFrequencyType repaymentFrequencyType, final Integer defaultNumberOfRepayments,
-            final Integer defaultMinNumberOfRepayments, final Integer defaultMaxNumberOfRepayments,
             final AmortizationMethod amortizationMethod, final BigDecimal inArrearsTolerance) {
         this.currency = currency;
         this.principal = defaultPrincipal;
-        this.minPrincipal = defaultMinPrincipal;
-        this.maxPrincipal = defaultMaxPrincipal;
         this.nominalInterestRatePerPeriod = defaultNominalInterestRatePerPeriod;
-        this.minNominalInterestRatePerPeriod = defaultMinNominalInterestRatePerPeriod;
-        this.maxNominalInterestRatePerPeriod = defaultMaxNominalInterestRatePerPeriod;
         this.interestPeriodFrequencyType = interestPeriodFrequencyType;
         this.annualNominalInterestRate = defaultAnnualNominalInterestRate;
         this.interestMethod = interestMethod;
@@ -139,8 +111,6 @@ public class LoanProductRelatedDetail implements LoanProductMinimumRepaymentSche
         this.repayEvery = repayEvery;
         this.repaymentPeriodFrequencyType = repaymentFrequencyType;
         this.numberOfRepayments = defaultNumberOfRepayments;
-        this.minNumberOfRepayments = defaultMinNumberOfRepayments;
-        this.maxNumberOfRepayments = defaultMaxNumberOfRepayments;
         this.amortizationMethod = amortizationMethod;
         if (inArrearsTolerance != null && BigDecimal.ZERO.compareTo(inArrearsTolerance) == 0) {
             this.inArrearsTolerance = null;
@@ -156,14 +126,6 @@ public class LoanProductRelatedDetail implements LoanProductMinimumRepaymentSche
     public Money getPrincipal() {
         return Money.of(this.currency, this.principal);
     }
-
-    public Money getMinPrincipal() {
-        return Money.of(this.currency, this.minPrincipal);
-    }
-    
-    public Money getMaxPrincipal() {
-        return Money.of(this.currency, this.maxPrincipal);
-    }
     
     public Money getInArrearsTolerance() {
         return Money.of(this.currency, this.inArrearsTolerance);
@@ -172,17 +134,7 @@ public class LoanProductRelatedDetail implements LoanProductMinimumRepaymentSche
     public BigDecimal getNominalInterestRatePerPeriod() {
         return BigDecimal.valueOf(Double.valueOf(this.nominalInterestRatePerPeriod.stripTrailingZeros().toString()));
     }
-    
-    public BigDecimal getMinNominalInterestRatePerPeriod() {
-        return this.minNominalInterestRatePerPeriod == null ? null : BigDecimal.valueOf(Double.valueOf(this.minNominalInterestRatePerPeriod
-                .stripTrailingZeros().toString()));
-    }
 
-    public BigDecimal getMaxNominalInterestRatePerPeriod() {
-        return this.maxNominalInterestRatePerPeriod == null ? null : BigDecimal.valueOf(Double.valueOf(this.maxNominalInterestRatePerPeriod
-                .stripTrailingZeros().toString()));
-    }
-    
     public PeriodFrequencyType getInterestPeriodFrequencyType() {
         return interestPeriodFrequencyType;
     }
@@ -212,14 +164,6 @@ public class LoanProductRelatedDetail implements LoanProductMinimumRepaymentSche
     @Override
     public Integer getNumberOfRepayments() {
         return numberOfRepayments;
-    }
-    
-    public Integer getMinNumberOfRepayments() {
-        return minNumberOfRepayments;
-    }
-
-    public Integer getMaxNumberOfRepayments() {
-        return maxNumberOfRepayments;
     }
     
     public AmortizationMethod getAmortizationMethod() {
@@ -264,22 +208,6 @@ public class LoanProductRelatedDetail implements LoanProductMinimumRepaymentSche
 
         final String localeAsInput = command.locale();
 
-        final String minPrincipalParamName = "minPrincipal";
-        if (command.isChangeInBigDecimalParameterNamedWithNullCheck(minPrincipalParamName, this.minPrincipal)) {
-            final BigDecimal newValue = command.bigDecimalValueOfParameterNamed(minPrincipalParamName);
-            actualChanges.put(minPrincipalParamName, newValue);
-            actualChanges.put("locale", localeAsInput);
-            this.minPrincipal = newValue;
-        }
-
-        final String maxPrincipalParamName = "maxPrincipal";
-        if (command.isChangeInBigDecimalParameterNamedWithNullCheck(maxPrincipalParamName, this.maxPrincipal)) {
-            final BigDecimal newValue = command.bigDecimalValueOfParameterNamed(maxPrincipalParamName);
-            actualChanges.put(maxPrincipalParamName, newValue);
-            actualChanges.put("locale", localeAsInput);
-            this.maxPrincipal = newValue;
-        }
-        
         final String principalParamName = "principal";
         if (command.isChangeInBigDecimalParameterNamed(principalParamName, this.principal)) {
             final BigDecimal newValue = command.bigDecimalValueOfParameterNamed(principalParamName);
@@ -302,22 +230,6 @@ public class LoanProductRelatedDetail implements LoanProductMinimumRepaymentSche
             actualChanges.put(repaymentFrequencyTypeParamName, newValue);
             actualChanges.put("locale", localeAsInput);
             this.repaymentPeriodFrequencyType = PeriodFrequencyType.fromInt(newValue);
-        }
-
-        final String minNumberOfRepaymentsParamName = "minNumberOfRepayments";
-        if (command.isChangeInIntegerParameterNamed(minNumberOfRepaymentsParamName, this.minNumberOfRepayments)) {
-            final Integer newValue = command.integerValueOfParameterNamed(minNumberOfRepaymentsParamName);
-            actualChanges.put(minNumberOfRepaymentsParamName, newValue);
-            actualChanges.put("locale", localeAsInput);
-            this.minNumberOfRepayments = newValue;
-        }
-        
-        final String maxNumberOfRepaymentsParamName = "maxNumberOfRepayments";
-        if (command.isChangeInIntegerParameterNamed(maxNumberOfRepaymentsParamName, this.maxNumberOfRepayments)) {
-            final Integer newValue = command.integerValueOfParameterNamed(maxNumberOfRepaymentsParamName);
-            actualChanges.put(maxNumberOfRepaymentsParamName, newValue);
-            actualChanges.put("locale", localeAsInput);
-            this.maxNumberOfRepayments = newValue;
         }
         
         final String numberOfRepaymentsParamName = "numberOfRepayments";
@@ -342,22 +254,6 @@ public class LoanProductRelatedDetail implements LoanProductMinimumRepaymentSche
             actualChanges.put(inArrearsToleranceParamName, newValue);
             actualChanges.put("locale", localeAsInput);
             this.inArrearsTolerance = newValue;
-        }
-
-        final String minInterestRatePerPeriodParamName = "minInterestRatePerPeriod";
-        if (command.isChangeInBigDecimalParameterNamedWithNullCheck(minInterestRatePerPeriodParamName, this.minNominalInterestRatePerPeriod)) {
-            final BigDecimal newValue = command.bigDecimalValueOfParameterNamed(minInterestRatePerPeriodParamName);
-            actualChanges.put(minInterestRatePerPeriodParamName, newValue);
-            actualChanges.put("locale", localeAsInput);
-            this.minNominalInterestRatePerPeriod = newValue;
-        }
-        
-        final String maxInterestRatePerPeriodParamName = "maxInterestRatePerPeriod";
-        if (command.isChangeInBigDecimalParameterNamedWithNullCheck(maxInterestRatePerPeriodParamName, this.maxNominalInterestRatePerPeriod)) {
-            final BigDecimal newValue = command.bigDecimalValueOfParameterNamed(maxInterestRatePerPeriodParamName);
-            actualChanges.put(maxInterestRatePerPeriodParamName, newValue);
-            actualChanges.put("locale", localeAsInput);
-            this.maxNominalInterestRatePerPeriod = newValue;
         }
         
         final String interestRatePerPeriodParamName = "interestRatePerPeriod";

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanproduct/service/LoanProductWritePlatformServiceJpaRepositoryImpl.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanproduct/service/LoanProductWritePlatformServiceJpaRepositoryImpl.java
@@ -132,12 +132,10 @@ public class LoanProductWritePlatformServiceJpaRepositoryImpl implements LoanPro
         try {
             this.context.authenticatedUser();
 
-            this.fromApiJsonDeserializer.validateForUpdate(command.json());
-
             final LoanProduct product = this.loanProductRepository.findOne(loanProductId);
             if (product == null) { throw new LoanProductNotFoundException(loanProductId); }
-
-            this.fromApiJsonDeserializer.validateMinMaxConstraints(command.parsedJson(), product.loanProductRelatedDetail(), "loanproduct");
+            
+            this.fromApiJsonDeserializer.validateForUpdate(command.json(), product);
             
             final Map<String, Object> changes = product.update(command, this.aprCalculator);
 

--- a/mifosng-provider/src/test/java/org/mifosplatform/portfolio/loanaccount/LoanProductRelatedDetailTestHelper.java
+++ b/mifosng-provider/src/test/java/org/mifosplatform/portfolio/loanaccount/LoanProductRelatedDetailTestHelper.java
@@ -21,13 +21,9 @@ public class LoanProductRelatedDetailTestHelper {
 
         MonetaryCurrency currency = new MonetaryCurrencyBuilder().withCode("USD").withDigitsAfterDecimal(2).build();
         BigDecimal defaultPrincipal = BigDecimal.valueOf(Double.valueOf("200000"));
-        BigDecimal defaultMinPrincipal = BigDecimal.valueOf(Double.valueOf("100000"));
-        BigDecimal defaultMaxPrincipal = BigDecimal.valueOf(Double.valueOf("250000"));
 
         // 2% per month, 24% per year
         BigDecimal defaultNominalInterestRatePerPeriod = BigDecimal.valueOf(Double.valueOf("2"));
-        BigDecimal defaultMinNominalInterestRatePerPeriod = BigDecimal.valueOf(Double.valueOf("1"));
-        BigDecimal defaultMaxNominalInterestRatePerPeriod = BigDecimal.valueOf(Double.valueOf("10"));
         PeriodFrequencyType interestPeriodFrequencyType = PeriodFrequencyType.MONTHS;
         BigDecimal defaultAnnualNominalInterestRate = BigDecimal.valueOf(Double.valueOf("24"));
 
@@ -37,29 +33,21 @@ public class LoanProductRelatedDetailTestHelper {
         PeriodFrequencyType repaymentFrequencyType = PeriodFrequencyType.MONTHS;
 
         Integer defaultNumberOfRepayments = Integer.valueOf(4);
-        Integer defaultMinNumberOfRepayments = Integer.valueOf(2);
-        Integer defaultMaxNumberOfRepayments = Integer.valueOf(6);
         AmortizationMethod amortizationMethod = AmortizationMethod.EQUAL_PRINCIPAL;
 
         BigDecimal inArrearsTolerance = BigDecimal.ZERO;
 
-        return createLoanProductRelatedDetail(currency, defaultPrincipal, defaultMinPrincipal, defaultMaxPrincipal,
-                defaultNominalInterestRatePerPeriod, defaultMinNominalInterestRatePerPeriod, defaultMaxNominalInterestRatePerPeriod,
-                interestPeriodFrequencyType, defaultAnnualNominalInterestRate, interestMethod, interestCalculationPeriodMethod, repayEvery,
-                repaymentFrequencyType, defaultNumberOfRepayments, defaultMinNumberOfRepayments, defaultMaxNumberOfRepayments,
-                amortizationMethod, inArrearsTolerance);
+        return createLoanProductRelatedDetail(currency, defaultPrincipal, defaultNominalInterestRatePerPeriod, interestPeriodFrequencyType,
+                defaultAnnualNominalInterestRate, interestMethod, interestCalculationPeriodMethod, repayEvery, repaymentFrequencyType,
+                defaultNumberOfRepayments, amortizationMethod, inArrearsTolerance);
     }
 
     public static LoanProductRelatedDetail createSettingsForEqualInstallmentAmortizationQuarterly() {
         MonetaryCurrency currency = new MonetaryCurrencyBuilder().withCode("USD").withDigitsAfterDecimal(2).build();
         BigDecimal defaultPrincipal = BigDecimal.valueOf(Double.valueOf("200000"));
-        BigDecimal defaultMinPrincipal = BigDecimal.valueOf(Double.valueOf("100000"));
-        BigDecimal defaultMaxPrincipal = BigDecimal.valueOf(Double.valueOf("250000"));
 
         // 2% per month, 24% per year
         BigDecimal defaultNominalInterestRatePerPeriod = BigDecimal.valueOf(Double.valueOf("2"));
-        BigDecimal defaultMinNominalInterestRatePerPeriod = BigDecimal.valueOf(Double.valueOf("2"));
-        BigDecimal defaultMaxNominalInterestRatePerPeriod = BigDecimal.valueOf(Double.valueOf("2"));
         PeriodFrequencyType interestPeriodFrequencyType = PeriodFrequencyType.MONTHS;
         BigDecimal defaultAnnualNominalInterestRate = BigDecimal.valueOf(Double.valueOf("24"));
 
@@ -69,30 +57,22 @@ public class LoanProductRelatedDetailTestHelper {
         PeriodFrequencyType repaymentFrequencyType = PeriodFrequencyType.MONTHS;
 
         Integer defaultNumberOfRepayments = Integer.valueOf(4);
-        Integer defaultMinNumberOfRepayments = Integer.valueOf(4);
-        Integer defaultMaxNumberOfRepayments = Integer.valueOf(4);
         AmortizationMethod amortizationMethod = AmortizationMethod.EQUAL_INSTALLMENTS;
 
         BigDecimal inArrearsTolerance = BigDecimal.ZERO;
 
-        return createLoanProductRelatedDetail(currency, defaultPrincipal, defaultMinPrincipal, defaultMaxPrincipal,
-                defaultNominalInterestRatePerPeriod, defaultMinNominalInterestRatePerPeriod, defaultMaxNominalInterestRatePerPeriod,
-                interestPeriodFrequencyType, defaultAnnualNominalInterestRate, interestMethod, interestCalculationPeriodMethod, repayEvery,
-                repaymentFrequencyType, defaultNumberOfRepayments, defaultMinNumberOfRepayments, defaultMaxNumberOfRepayments,
-                amortizationMethod, inArrearsTolerance);
+        return createLoanProductRelatedDetail(currency, defaultPrincipal, defaultNominalInterestRatePerPeriod, interestPeriodFrequencyType,
+                defaultAnnualNominalInterestRate, interestMethod, interestCalculationPeriodMethod, repayEvery, repaymentFrequencyType,
+                defaultNumberOfRepayments, amortizationMethod, inArrearsTolerance);
     }
 
     public static LoanProductRelatedDetail createSettingsForFlatQuarterly(final AmortizationMethod amortizationMethod) {
 
         MonetaryCurrency currency = new MonetaryCurrencyBuilder().withCode("USD").withDigitsAfterDecimal(2).build();
         BigDecimal defaultPrincipal = BigDecimal.valueOf(Double.valueOf("200000"));
-        BigDecimal defaultMinPrincipal = BigDecimal.valueOf(Double.valueOf("200000"));
-        BigDecimal defaultMaxPrincipal = BigDecimal.valueOf(Double.valueOf("200000"));
-
+        
         // 2% per month, 24% per year
         BigDecimal defaultNominalInterestRatePerPeriod = BigDecimal.valueOf(Double.valueOf("2"));
-        BigDecimal defaultMinNominalInterestRatePerPeriod = BigDecimal.valueOf(Double.valueOf("2"));
-        BigDecimal defaultMaxNominalInterestRatePerPeriod = BigDecimal.valueOf(Double.valueOf("2"));
         PeriodFrequencyType interestPeriodFrequencyType = PeriodFrequencyType.MONTHS;
         BigDecimal defaultAnnualNominalInterestRate = BigDecimal.valueOf(Double.valueOf("24"));
 
@@ -102,29 +82,21 @@ public class LoanProductRelatedDetailTestHelper {
         PeriodFrequencyType repaymentFrequencyType = PeriodFrequencyType.MONTHS;
 
         Integer defaultNumberOfRepayments = Integer.valueOf(4);
-        Integer defaultMinNumberOfRepayments = Integer.valueOf(4);
-        Integer defaultMaxNumberOfRepayments = Integer.valueOf(4);
 
         BigDecimal inArrearsTolerance = BigDecimal.ZERO;
 
-        return createLoanProductRelatedDetail(currency, defaultPrincipal, defaultMinPrincipal, defaultMaxPrincipal,
-                defaultNominalInterestRatePerPeriod, defaultMinNominalInterestRatePerPeriod, defaultMaxNominalInterestRatePerPeriod,
-                interestPeriodFrequencyType, defaultAnnualNominalInterestRate, interestMethod, interestCalculationPeriodMethod, repayEvery,
-                repaymentFrequencyType, defaultNumberOfRepayments, defaultMinNumberOfRepayments, defaultMaxNumberOfRepayments,
-                amortizationMethod, inArrearsTolerance);
+        return createLoanProductRelatedDetail(currency, defaultPrincipal, defaultNominalInterestRatePerPeriod, interestPeriodFrequencyType,
+                defaultAnnualNominalInterestRate, interestMethod, interestCalculationPeriodMethod, repayEvery, repaymentFrequencyType,
+                defaultNumberOfRepayments, amortizationMethod, inArrearsTolerance);
     }
 
     public static LoanProductRelatedDetail createSettingsForIrregularFlatEveryFourMonths() {
 
         MonetaryCurrency currency = new MonetaryCurrencyBuilder().withCode("KSH").withDigitsAfterDecimal(0).build();
         BigDecimal defaultPrincipal = BigDecimal.valueOf(Double.valueOf("15000"));
-        BigDecimal defaultMinPrincipal = BigDecimal.valueOf(Double.valueOf("15000"));
-        BigDecimal defaultMaxPrincipal = BigDecimal.valueOf(Double.valueOf("15000"));
 
         // 2% per month, 24% per year
         BigDecimal defaultNominalInterestRatePerPeriod = BigDecimal.valueOf(Double.valueOf("2"));
-        BigDecimal defaultMinNominalInterestRatePerPeriod = BigDecimal.valueOf(Double.valueOf("2"));
-        BigDecimal defaultMaxNominalInterestRatePerPeriod = BigDecimal.valueOf(Double.valueOf("4"));
         PeriodFrequencyType interestPeriodFrequencyType = PeriodFrequencyType.MONTHS;
         BigDecimal defaultAnnualNominalInterestRate = BigDecimal.valueOf(Double.valueOf("24"));
 
@@ -134,31 +106,25 @@ public class LoanProductRelatedDetailTestHelper {
         PeriodFrequencyType repaymentFrequencyType = PeriodFrequencyType.MONTHS;
 
         Integer defaultNumberOfRepayments = Integer.valueOf(2);
-        Integer defaultMinNumberOfRepayments = Integer.valueOf(2);
-        Integer defaultMaxNumberOfRepayments = Integer.valueOf(2);
 
         BigDecimal inArrearsTolerance = BigDecimal.ZERO;
 
         AmortizationMethod amortizationMethod = AmortizationMethod.EQUAL_PRINCIPAL;
 
-        return createLoanProductRelatedDetail(currency, defaultPrincipal, defaultMinPrincipal, defaultMaxPrincipal,
-                defaultNominalInterestRatePerPeriod, defaultMinNominalInterestRatePerPeriod, defaultMaxNominalInterestRatePerPeriod, interestPeriodFrequencyType, defaultAnnualNominalInterestRate, interestMethod,
-                interestCalculationPeriodMethod, repayEvery, repaymentFrequencyType, defaultNumberOfRepayments, defaultMinNumberOfRepayments, defaultMaxNumberOfRepayments, amortizationMethod,
-                inArrearsTolerance);
+        return createLoanProductRelatedDetail(currency, defaultPrincipal, defaultNominalInterestRatePerPeriod, interestPeriodFrequencyType,
+                defaultAnnualNominalInterestRate, interestMethod, interestCalculationPeriodMethod, repayEvery, repaymentFrequencyType,
+                defaultNumberOfRepayments, amortizationMethod, inArrearsTolerance);
     }
 
     private static LoanProductRelatedDetail createLoanProductRelatedDetail(MonetaryCurrency currency, BigDecimal defaultPrincipal,
-            BigDecimal defaultMinPrincipal, BigDecimal defaultMaxPrincipal, BigDecimal defaultNominalInterestRatePerPeriod,
-            BigDecimal defaultMinNominalInterestRatePerPeriod, BigDecimal defaultMaxNominalInterestRatePerPeriod,
-            PeriodFrequencyType interestPeriodFrequencyType, BigDecimal defaultAnnualNominalInterestRate, InterestMethod interestMethod,
+            BigDecimal defaultNominalInterestRatePerPeriod, PeriodFrequencyType interestPeriodFrequencyType,
+            BigDecimal defaultAnnualNominalInterestRate, InterestMethod interestMethod,
             InterestCalculationPeriodMethod interestCalculationPeriodMethod, Integer repayEvery,
-            PeriodFrequencyType repaymentFrequencyType, Integer defaultNumberOfRepayments, Integer defaultMinNumberOfRepayments,
-            Integer defaultMaxNumberOfRepayments, AmortizationMethod amortizationMethod, BigDecimal inArrearsTolerance) {
+            PeriodFrequencyType repaymentFrequencyType, Integer defaultNumberOfRepayments, AmortizationMethod amortizationMethod,
+            BigDecimal inArrearsTolerance) {
 
-        return new LoanProductRelatedDetail(currency, defaultPrincipal, defaultMinPrincipal, defaultMaxPrincipal,
-                defaultNominalInterestRatePerPeriod, defaultMinNominalInterestRatePerPeriod, defaultMaxNominalInterestRatePerPeriod,
-                interestPeriodFrequencyType, defaultAnnualNominalInterestRate, interestMethod, interestCalculationPeriodMethod, repayEvery,
-                repaymentFrequencyType, defaultNumberOfRepayments, defaultMinNumberOfRepayments, defaultMaxNumberOfRepayments,
-                amortizationMethod, inArrearsTolerance);
+        return new LoanProductRelatedDetail(currency, defaultPrincipal, defaultNominalInterestRatePerPeriod, interestPeriodFrequencyType,
+                defaultAnnualNominalInterestRate, interestMethod, interestCalculationPeriodMethod, repayEvery, repaymentFrequencyType,
+                defaultNumberOfRepayments, amortizationMethod, inArrearsTolerance);
     }
 }


### PR DESCRIPTION
Hi Keith,

This commit includes changes to min and max constraints.
1. Removed min and max fields from m_loan
2. All min and max validations are done using LoanProduct data for create loan application/modify loan application.

Regards
Ashok
