### PR TITLE
added foreign key contraint for group and client in loan table

### DIFF
--- a/mifosng-db/migrations/core_db/V24__add-group-client-foreign-key-constraint-in-loan-table.sql
+++ b/mifosng-db/migrations/core_db/V24__add-group-client-foreign-key-constraint-in-loan-table.sql
@@ -1,0 +1,7 @@
+ALTER TABLE m_loan
+ADD CONSTRAINT `fk_m_group_client_001`
+FOREIGN KEY (`group_id` , `client_id` )
+REFERENCES m_group_client (`group_id` , `client_id` )
+ON DELETE NO ACTION
+ON UPDATE NO ACTION
+, ADD INDEX `fk_m_group_client_001_idx` (`group_id` ASC, `client_id` ASC) ;


### PR DESCRIPTION
Hi Keith,

In this commit added foreign key constraint for group_id and client_id in m_loan table.

Regards
Ashok
