### PR TITLE
wip:added separate commands for associating/disassociating a client to group

### DIFF
--- a/mifosng-db/migrations/core_db/V32__associate-disassociate-clients-from-group-permissions.sql
+++ b/mifosng-db/migrations/core_db/V32__associate-disassociate-clients-from-group-permissions.sql
@@ -1,0 +1,4 @@
+INSERT INTO `m_permission` (`grouping`, `code`, `entity_name`, `action_name`, `can_maker_checker`) VALUES ('portfolio', 'ASSOCIATECLIENTS_GROUP', 'GROUP', 'ASSOCIATECLIENTS', 0);
+
+
+INSERT INTO `m_permission` (`grouping`, `code`, `entity_name`, `action_name`, `can_maker_checker`) VALUES ('portfolio', 'DISASSOCIATECLIENTS_GROUP', 'GROUP', 'DISASSOCIATECLIENTS', 0);

--- a/mifosng-provider/src/main/java/org/mifosplatform/commands/domain/CommandWrapper.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/commands/domain/CommandWrapper.java
@@ -498,4 +498,12 @@ public class CommandWrapper {
     public boolean isReportResource() {
         return this.entityName.equalsIgnoreCase("REPORT");
     }
+    
+    public boolean isAssociateClients(){
+        return this.actionName.equalsIgnoreCase("ASSOCIATECLIENTS");
+    }
+    
+    public boolean isDisassociateClients(){
+        return this.actionName.equalsIgnoreCase("DISASSOCIATECLIENTS");
+    }
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/commands/service/CommandWrapperBuilder.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/commands/service/CommandWrapperBuilder.java
@@ -857,6 +857,24 @@ public class CommandWrapperBuilder {
         return this;
     }
 
+    public CommandWrapperBuilder associateClientsToGroup(final Long groupId) {
+        this.actionName = "ASSOCIATECLIENTS";
+        this.entityName = "GROUP";
+        this.entityId = groupId;
+        this.groupId = groupId;
+        this.href = "/groups/" + groupId + "?command=associateClients";
+        return this;
+    }
+    
+    public CommandWrapperBuilder disassociateClientsFromGroup(final Long groupId) {
+        this.actionName = "DISASSOCIATECLIENTS";
+        this.entityName = "GROUP";
+        this.entityId = groupId;
+        this.groupId = groupId;
+        this.href = "/groups/" + groupId + "?command=disassociateClients";
+        return this;
+    }
+    
     public CommandWrapperBuilder unassignStaff(final Long groupId) {
         this.actionName = "UNASSIGNSTAFF";
         this.entityName = "GROUP";

--- a/mifosng-provider/src/main/java/org/mifosplatform/commands/service/SynchronousCommandProcessingService.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/commands/service/SynchronousCommandProcessingService.java
@@ -400,6 +400,10 @@ public class SynchronousCommandProcessingService implements CommandProcessingSer
                 handler = applicationContext.getBean("deleteGroupCommandHandler", NewCommandSourceHandler.class);
             } else if (wrapper.isGroupActivation()) {
                 handler = applicationContext.getBean("activateGroupCommandHandler", NewCommandSourceHandler.class);
+            } else if (wrapper.isAssociateClients()) {
+                handler = applicationContext.getBean("associateClientsToGroupCommandHandler", NewCommandSourceHandler.class);
+            } else if (wrapper.isDisassociateClients()) {
+                handler = applicationContext.getBean("disassociateClientsFromGroupCommandHandler", NewCommandSourceHandler.class);
             } else {
                 throw new UnsupportedCommandException(wrapper.commandName());
             }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/api/GroupsApiResource.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/api/GroupsApiResource.java
@@ -221,6 +221,12 @@ public class GroupsApiResource {
         if (is(commandParam, "activate")) {
             final CommandWrapper commandRequest = builder.activateGroup(groupId).build();
             result = this.commandsSourceWritePlatformService.logCommandSource(commandRequest);
+        }else if (is(commandParam, "associateClients")) {
+            final CommandWrapper commandRequest = builder.associateClientsToGroup(groupId).build();
+            result = this.commandsSourceWritePlatformService.logCommandSource(commandRequest);
+        }else if (is(commandParam, "disassociateClients")) {
+            final CommandWrapper commandRequest = builder.disassociateClientsFromGroup(groupId).build();
+            result = this.commandsSourceWritePlatformService.logCommandSource(commandRequest);
         }
 
         if (result == null) {

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/domain/Group.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/domain/Group.java
@@ -39,6 +39,8 @@ import org.mifosplatform.organisation.office.domain.Office;
 import org.mifosplatform.organisation.staff.domain.Staff;
 import org.mifosplatform.portfolio.client.domain.Client;
 import org.mifosplatform.portfolio.group.api.GroupingTypesApiConstants;
+import org.mifosplatform.portfolio.group.exception.ClientExistInGroupException;
+import org.mifosplatform.portfolio.group.exception.ClientNotInGroupException;
 import org.springframework.data.jpa.domain.AbstractPersistable;
 
 import com.google.common.collect.Sets;
@@ -312,6 +314,33 @@ public final class Group extends AbstractPersistable<Long> {
         return differences;
     }
 
+    public List<String> associateClients(final Set<Client> clientMembersSet) {
+        List<String> differences = new ArrayList<String>();
+        for (Client client : clientMembersSet) {
+            if(this.hasClientAsMember(client)){
+                throw new ClientExistInGroupException(client.getId(), this.getId());
+            }
+            this.clientMembers.add(client);
+            differences.add(client.getId().toString());
+        }
+
+        return differences;
+    }
+    
+    public List<String> disassociateClients(final Set<Client> clientMembersSet) {
+        List<String> differences = new ArrayList<String>();
+        for (Client client : clientMembersSet) {
+            if(this.hasClientAsMember(client)){
+                this.clientMembers.remove(client);
+                differences.add(client.getId().toString());
+            }else{
+                throw new ClientNotInGroupException(client.getId(), this.getId());
+            }            
+        }
+
+        return differences;
+    } 
+    
     private String[] getClientIds(final Set<Client> clients) {
         String[] clientIds = new String[clients.size()];
         Iterator<Client> it = clients.iterator();

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/exception/ClientExistInGroupException.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/exception/ClientExistInGroupException.java
@@ -1,0 +1,17 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.mifosplatform.portfolio.group.exception;
+
+import org.mifosplatform.infrastructure.core.exception.AbstractPlatformDomainRuleException;
+
+public class ClientExistInGroupException extends AbstractPlatformDomainRuleException {
+
+    public ClientExistInGroupException(final Long clientId, final Long groupId) {
+        super("error.msg.group.client.exist.in.group", "Client with identifier " + clientId + " is already exists in Group with identifier " + groupId,
+                clientId, groupId);
+    }
+
+}

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/exception/GroupLoanExistsException.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/exception/GroupLoanExistsException.java
@@ -1,0 +1,15 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.mifosplatform.portfolio.group.exception;
+
+import org.mifosplatform.infrastructure.core.exception.AbstractPlatformDomainRuleException;
+
+public class GroupLoanExistsException extends AbstractPlatformDomainRuleException {
+
+    public GroupLoanExistsException(final String action, String postFix, String defaultUserMessage, Object... defaultUserMessageArgs) {
+        super("error.msg.group." + action + "." + postFix, defaultUserMessage, defaultUserMessageArgs);
+    }
+}

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/handler/AssociateClientsToGroupCommandHandler.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/handler/AssociateClientsToGroupCommandHandler.java
@@ -1,0 +1,32 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.mifosplatform.portfolio.group.handler;
+
+import org.mifosplatform.commands.handler.NewCommandSourceHandler;
+import org.mifosplatform.infrastructure.core.api.JsonCommand;
+import org.mifosplatform.infrastructure.core.data.CommandProcessingResult;
+import org.mifosplatform.portfolio.group.service.GroupingTypesWritePlatformService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AssociateClientsToGroupCommandHandler implements NewCommandSourceHandler {
+
+    private final GroupingTypesWritePlatformService writePlatformService;
+
+    @Autowired
+    public AssociateClientsToGroupCommandHandler(final GroupingTypesWritePlatformService clientWritePlatformService) {
+        this.writePlatformService = clientWritePlatformService;
+    }
+
+    @Transactional
+    @Override
+    public CommandProcessingResult processCommand(final JsonCommand command) {
+
+        return this.writePlatformService.associateClientsToGroup(command.entityId(), command);
+    }
+}

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/handler/DisassociateClientsFromGroupCommandHandler.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/handler/DisassociateClientsFromGroupCommandHandler.java
@@ -1,0 +1,31 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.mifosplatform.portfolio.group.handler;
+
+import org.mifosplatform.commands.handler.NewCommandSourceHandler;
+import org.mifosplatform.infrastructure.core.api.JsonCommand;
+import org.mifosplatform.infrastructure.core.data.CommandProcessingResult;
+import org.mifosplatform.portfolio.group.service.GroupingTypesWritePlatformService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DisassociateClientsFromGroupCommandHandler implements NewCommandSourceHandler {
+
+    private final GroupingTypesWritePlatformService writePlatformService;
+
+    @Autowired
+    public DisassociateClientsFromGroupCommandHandler(final GroupingTypesWritePlatformService clientWritePlatformService) {
+        this.writePlatformService = clientWritePlatformService;
+    }
+
+    @Transactional
+    @Override
+    public CommandProcessingResult processCommand(final JsonCommand command) {
+        return this.writePlatformService.disassociateClientsFromGroup(command.entityId(), command);
+    }
+}

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/serialization/GroupingTypesDataValidator.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/serialization/GroupingTypesDataValidator.java
@@ -344,4 +344,44 @@ public final class GroupingTypesDataValidator {
 
         if (!dataValidationErrors.isEmpty()) { throw new PlatformApiDataValidationException(dataValidationErrors); }
     }
+    
+    public void validateForAssociateClients(final String json){
+
+        if (StringUtils.isBlank(json)) { throw new InvalidJsonException(); }
+
+        final Type typeOfMap = new TypeToken<Map<String, Object>>() {}.getType();
+
+        final Set<String> supportedParameters = new HashSet<String>(Arrays.asList(GroupingTypesApiConstants.clientMembersParamName));
+
+        this.fromApiJsonHelper.checkForUnsupportedParameters(typeOfMap, json, supportedParameters);
+        final JsonElement element = this.fromApiJsonHelper.parse(json);
+
+        final List<ApiParameterError> dataValidationErrors = new ArrayList<ApiParameterError>();
+
+        final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors).resource("group");
+        final String[] clients = fromApiJsonHelper.extractArrayNamed(GroupingTypesApiConstants.clientMembersParamName, element);
+        baseDataValidator.reset().parameter(GroupingTypesApiConstants.clientMembersParamName).value(clients).arrayNotEmpty();
+        
+        throwExceptionIfValidationWarningsExist(dataValidationErrors);
+    }
+    
+    public void validateForDisassociateClients(final String json){
+
+        if (StringUtils.isBlank(json)) { throw new InvalidJsonException(); }
+
+        final Type typeOfMap = new TypeToken<Map<String, Object>>() {}.getType();
+
+        final Set<String> supportedParameters = new HashSet<String>(Arrays.asList(GroupingTypesApiConstants.clientMembersParamName));
+
+        this.fromApiJsonHelper.checkForUnsupportedParameters(typeOfMap, json, supportedParameters);
+        final JsonElement element = this.fromApiJsonHelper.parse(json);
+
+        final List<ApiParameterError> dataValidationErrors = new ArrayList<ApiParameterError>();
+
+        final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors).resource("group");
+        final String[] clients = fromApiJsonHelper.extractArrayNamed(GroupingTypesApiConstants.clientMembersParamName, element);
+        baseDataValidator.reset().parameter(GroupingTypesApiConstants.clientMembersParamName).value(clients).arrayNotEmpty();
+        
+        throwExceptionIfValidationWarningsExist(dataValidationErrors);
+    }
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/service/GroupingTypesWritePlatformService.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/service/GroupingTypesWritePlatformService.java
@@ -22,5 +22,9 @@ public interface GroupingTypesWritePlatformService {
 
     CommandProcessingResult deleteGroup(Long groupId);
 
-    CommandProcessingResult unassignStaff(Long grouptId, JsonCommand command);
+    CommandProcessingResult unassignStaff(Long groupId, JsonCommand command);
+    
+    CommandProcessingResult associateClientsToGroup(Long groupId, JsonCommand command);
+    
+    CommandProcessingResult disassociateClientsFromGroup(Long groupId, JsonCommand command);    
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/domain/Loan.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/domain/Loan.java
@@ -89,11 +89,11 @@ public class Loan extends AbstractPersistable<Long> {
     @Column(name = "external_id")
     private String externalId;
 
-    @ManyToOne(optional = true)
+    @ManyToOne
     @JoinColumn(name = "client_id", nullable = true)
     private Client client;
 
-    @ManyToOne(optional = true)
+    @ManyToOne
     @JoinColumn(name = "group_id", nullable = true)
     private Group group;
 
@@ -300,7 +300,7 @@ public class Loan extends AbstractPersistable<Long> {
     }
 
     protected Loan() {
-        //
+        this.client = null;
     }
 
     private Loan(final String accountNo, final Client client, final Group group, final Integer loanType, final Fund fund, final Staff loanOfficer,

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/domain/LoanRepository.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/domain/LoanRepository.java
@@ -5,10 +5,15 @@
  */
 package org.mifosplatform.portfolio.loanaccount.domain;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface LoanRepository extends JpaRepository<Loan, Long>,
 		JpaSpecificationExecutor<Loan> {
-	// no added behaviour
+        @Query("from Loan loan where loan.client.id = :clientId and loan.group.id = :groupId")
+	List<Loan> findByClientIdAndGroupId(@Param("clientId") Long clientId, @Param("groupId") Long groupId);
 }


### PR DESCRIPTION
Hi Keith,

Following are the changes made in this pull request
1. Removed clients associating/disassociating from group update.
2. Added separate commands to support associate/disassociate clients to group.

the allowed commands are command=[associateClients, disassociateClients]

I am working on UI to support above changes.
UI changes would be
1. Remove associate/disassociate of clients feature from update group
2. Provide a separate button to associate clients to group
3. In group context, under clients tab, provide "Remove from group" button to disassociate.

Regards
Ashok
