### PR TITLE
MIFOSX-40: Tenant Subscription

### DIFF
--- a/mifosng-db/migrations/core_db/V40__permission_updates.sql
+++ b/mifosng-db/migrations/core_db/V40__permission_updates.sql
@@ -1,0 +1,5 @@
+
+INSERT INTO `m_permission`
+(`grouping`, `code`, `entity_name`, `action_name`, `can_maker_checker`) VALUES
+('authorisation', 'CREATE_TENANT', 'TENANT', 'CREATE', 0);
+

--- a/mifosng-db/migrations/list_db/V1__mifos-platform-shared-tenants.sql
+++ b/mifosng-db/migrations/list_db/V1__mifos-platform-shared-tenants.sql
@@ -37,7 +37,9 @@ CREATE TABLE `tenants` (
   `schema_username` varchar(100) NOT NULL DEFAULT 'root',
   `schema_password` varchar(100) NOT NULL DEFAULT 'mysql',
   `auto_update` tinyint(1) NOT NULL DEFAULT '1',
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `tenant_identifier` (`identifier`),
+  UNIQUE KEY `tenant_schema_name` (`schema_name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/mifosng-provider/src/main/java/org/mifosplatform/commands/domain/CommandWrapper.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/commands/domain/CommandWrapper.java
@@ -512,4 +512,8 @@ public class CommandWrapper {
     public boolean isDisassociateClients() {
         return this.actionName.equalsIgnoreCase("DISASSOCIATECLIENTS");
     }
+    
+    public boolean isTenantResource() {
+    	return this.entityName.equalsIgnoreCase("TENANT");
+    }
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/commands/service/CommandWrapperBuilder.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/commands/service/CommandWrapperBuilder.java
@@ -991,4 +991,12 @@ public class CommandWrapperBuilder {
         this.href = "/accountingrules/" + accountingRuleId;
         return this;
     }
+    
+    public CommandWrapperBuilder createTenant() {
+    	this.actionName = "CREATE";
+    	this.entityName = "TENANT";
+    	this.entityId = null;
+    	this.href = "/tenants";
+    	return this;
+    }
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/commands/service/SynchronousCommandProcessingService.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/commands/service/SynchronousCommandProcessingService.java
@@ -443,6 +443,14 @@ public class SynchronousCommandProcessingService implements CommandProcessingSer
                 throw new UnsupportedCommandException(wrapper.commandName());
             }
 
+        } else if (wrapper.isTenantResource()) {
+        	
+        	if (wrapper.isCreate()) {
+        		handler = applicationContext.getBean("createTenantCommandHandler", NewCommandSourceHandler.class);
+        	} else {
+        		throw new UnsupportedCommandException(wrapper.commandName());
+        	}
+        	
         } else {
             throw new UnsupportedCommandException(wrapper.commandName());
         }

--- a/mifosng-provider/src/main/java/org/mifosplatform/commands/service/TenantCommandSourceWritePlaftormServiceImpl.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/commands/service/TenantCommandSourceWritePlaftormServiceImpl.java
@@ -1,0 +1,101 @@
+package org.mifosplatform.commands.service;
+
+import org.mifosplatform.commands.domain.CommandSource;
+import org.mifosplatform.commands.domain.CommandSourceRepository;
+import org.mifosplatform.commands.domain.CommandWrapper;
+import org.mifosplatform.commands.exception.CommandNotAwaitingApprovalException;
+import org.mifosplatform.commands.exception.CommandNotFoundException;
+import org.mifosplatform.commands.exception.RollbackTransactionAsCommandIsNotApprovedByCheckerException;
+import org.mifosplatform.infrastructure.core.api.JsonCommand;
+import org.mifosplatform.infrastructure.core.data.CommandProcessingResult;
+import org.mifosplatform.infrastructure.core.serialization.FromJsonHelper;
+import org.mifosplatform.infrastructure.security.service.PlatformSecurityContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.google.gson.JsonElement;
+
+@Service
+public class TenantCommandSourceWritePlaftormServiceImpl implements TenantCommandSourceWritePlatformService {
+
+	private final PlatformSecurityContext context;
+	private final CommandSourceRepository commandSourceRepository;
+	private final FromJsonHelper fromApiJsonHelper;
+	private final CommandProcessingService processAndLogCommandService;
+	
+	@Autowired
+	public TenantCommandSourceWritePlaftormServiceImpl(final PlatformSecurityContext context,
+			final CommandSourceRepository commandSourceRepository, final FromJsonHelper fromApiJsonHelper,
+			final CommandProcessingService processAndLogCommandService) {
+		
+		this.context = context;
+		this.commandSourceRepository = commandSourceRepository;
+		this.fromApiJsonHelper = fromApiJsonHelper;
+		this.processAndLogCommandService = processAndLogCommandService;
+	}
+	
+	@Override
+	public CommandProcessingResult logCommandSource(final CommandWrapper wrapper) {
+
+        context.authenticatedUser().validateHasPermissionTo(wrapper.getTaskPermissionName());
+        
+        final String json = wrapper.getJson();
+        CommandProcessingResult result = null;
+        try {
+            final JsonElement parsedCommand = this.fromApiJsonHelper.parse(json);
+            final JsonCommand command = JsonCommand.from(json, parsedCommand, this.fromApiJsonHelper, wrapper.getEntityName(),
+                    wrapper.getEntityId(), wrapper.getSubentityId(), wrapper.getGroupId(), wrapper.getClientId(), wrapper.getLoanId(),
+                    wrapper.getSavingsId(), wrapper.getCodeId(), wrapper.getSupportedEntityType(), wrapper.getSupportedEntityId(),
+                    wrapper.getTransactionId());
+
+            result = this.processAndLogCommandService.processAndLogCommand(wrapper, command, false);
+        } catch (RollbackTransactionAsCommandIsNotApprovedByCheckerException e) {
+
+            result = this.processAndLogCommandService.logCommand(e.getCommandSourceResult());
+        }
+
+        return result;
+	}
+
+	@Override
+	public CommandProcessingResult approveEntry(final Long makerCheckerId) {
+
+        CommandSource commandSourceInput = validateMakerCheckerTransaction(makerCheckerId);
+
+        final CommandWrapper wrapper = CommandWrapper.fromExistingCommand(makerCheckerId, commandSourceInput.getActionName(),
+                commandSourceInput.getEntityName(), commandSourceInput.resourceId(), commandSourceInput.subresourceId(),
+                commandSourceInput.getResourceGetUrl());
+
+        final JsonElement parsedCommand = this.fromApiJsonHelper.parse(commandSourceInput.json());
+        final JsonCommand command = JsonCommand.fromExistingCommand(makerCheckerId, commandSourceInput.json(), parsedCommand,
+                this.fromApiJsonHelper, commandSourceInput.getEntityName(), commandSourceInput.resourceId(),
+                commandSourceInput.subresourceId());
+
+        final boolean makerCheckerApproval = true;
+        return this.processAndLogCommandService.processAndLogCommand(wrapper, command, makerCheckerApproval);
+    }
+
+	@Transactional
+    @Override
+    public Long deleteEntry(final Long makerCheckerId) {
+
+        validateMakerCheckerTransaction(makerCheckerId);
+
+        this.commandSourceRepository.delete(makerCheckerId);
+
+        return makerCheckerId;
+    }
+	
+	private CommandSource validateMakerCheckerTransaction(final Long makerCheckerId) {
+
+        final CommandSource commandSourceInput = this.commandSourceRepository.findOne(makerCheckerId);
+        if (commandSourceInput == null) { throw new CommandNotFoundException(makerCheckerId); }
+        if (!(commandSourceInput.isMarkedAsAwaitingApproval())) { throw new CommandNotAwaitingApprovalException(makerCheckerId); }
+
+        context.authenticatedUser().validateHasCheckerPermissionTo(commandSourceInput.getPermissionCode());
+
+        return commandSourceInput;
+    }
+	
+}

--- a/mifosng-provider/src/main/java/org/mifosplatform/commands/service/TenantCommandSourceWritePlatformService.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/commands/service/TenantCommandSourceWritePlatformService.java
@@ -1,0 +1,13 @@
+package org.mifosplatform.commands.service;
+
+import org.mifosplatform.commands.domain.CommandWrapper;
+import org.mifosplatform.infrastructure.core.data.CommandProcessingResult;
+
+public interface TenantCommandSourceWritePlatformService {
+
+	CommandProcessingResult logCommandSource(CommandWrapper commandRequest);
+
+	CommandProcessingResult approveEntry(Long id);
+
+	Long deleteEntry(Long makerCheckerId);
+}

--- a/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/api/TenantApiResource.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/api/TenantApiResource.java
@@ -1,0 +1,46 @@
+package org.mifosplatform.infrastructure.core.api;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.mifosplatform.commands.domain.CommandWrapper;
+import org.mifosplatform.commands.service.CommandWrapperBuilder;
+import org.mifosplatform.commands.service.TenantCommandSourceWritePlatformService;
+import org.mifosplatform.infrastructure.core.data.CommandProcessingResult;
+import org.mifosplatform.infrastructure.core.data.TenantData;
+import org.mifosplatform.infrastructure.core.serialization.DefaultToApiJsonSerializer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Path("/tenants")
+@Component
+@Scope("singleton")
+public class TenantApiResource {
+	
+	private final DefaultToApiJsonSerializer<TenantData> toApiJsonSerializer;
+	private final TenantCommandSourceWritePlatformService commandsSourceWritePlatformService;
+	
+	@Autowired
+	public TenantApiResource(final DefaultToApiJsonSerializer<TenantData> toApiJsonSerializer,
+			final TenantCommandSourceWritePlatformService commandsSourceWritePlatformService) {
+		
+		this.toApiJsonSerializer = toApiJsonSerializer;
+		this.commandsSourceWritePlatformService = commandsSourceWritePlatformService;
+	}
+	
+	@POST
+	@Consumes({ MediaType.APPLICATION_JSON })
+	@Produces({ MediaType.APPLICATION_JSON })
+	public String createTenant(final String apiRequestBodyAsJson) {
+		
+		final CommandWrapper commandRequest = new CommandWrapperBuilder().createTenant().withJson(apiRequestBodyAsJson).build();
+		
+		final CommandProcessingResult result = this.commandsSourceWritePlatformService.logCommandSource(commandRequest);
+		
+		return this.toApiJsonSerializer.serialize(result);
+	}
+}

--- a/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/data/TenantData.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/data/TenantData.java
@@ -1,0 +1,92 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.mifosplatform.infrastructure.core.data;
+
+import java.lang.SuppressWarnings;
+import java.util.Date;
+
+public class TenantData {
+
+	@SuppressWarnings("unused")
+	private Long id;
+	
+	@SuppressWarnings("unused")
+	private String identifier;
+
+	@SuppressWarnings("unused")
+	private String name;
+
+	@SuppressWarnings("unused")
+	private String schemaName;
+
+	@SuppressWarnings("unused")
+	private String timezoneId;
+
+	@SuppressWarnings("unused")
+	private Integer countryId;
+
+	@SuppressWarnings("unused")
+	private Date joinedDate;
+
+	@SuppressWarnings("unused")
+	private Date createdDate;
+
+	@SuppressWarnings("unused")
+	private Date lastModified;
+
+	@SuppressWarnings("unused")
+	private String schemaServer;
+
+	@SuppressWarnings("unused")
+	private String schemaServerPort;
+
+	@SuppressWarnings("unused")
+	private String schemaUsername;
+
+	@SuppressWarnings("unused")
+	private String schemaPassword;
+
+	@SuppressWarnings("unused")
+	private Short autoUpdate;
+
+	public static TenantData instance(final Long id, final String identifier, final String name,
+			final String schemaName, final String timezoneId,
+			final Integer countryId, final Date joinedDate,
+			final Date createdDate, final Date lastModified,
+			final String schemaServer, final String schemaServerPort,
+			final String schemaUsername, final String schemaPassword,
+			final Short autoUpdate) {
+		
+		return new TenantData(id, identifier, name, schemaName, timezoneId,
+				countryId, joinedDate, createdDate, lastModified, schemaServer,
+				schemaServerPort, schemaUsername, schemaPassword, autoUpdate);
+	}
+	
+	private TenantData(final Long id, final String identifier, final String name,
+			final String schemaName, final String timezoneId,
+			final Integer countryId, final Date joinedDate,
+			final Date createdDate, final Date lastModified,
+			final String schemaServer, final String schemaServerPort,
+			final String schemaUsername, final String schemaPassword,
+			final Short autoUpdate) {
+
+		this.id = id;
+		this.identifier = identifier;
+		this.name = name;
+		this.schemaName = schemaName;
+		this.timezoneId = timezoneId;
+		this.countryId = countryId;
+		this.joinedDate = joinedDate;
+		this.createdDate = createdDate;
+		this.lastModified = lastModified;
+		this.schemaServer = schemaServer;
+		this.schemaServerPort = schemaServerPort;
+		this.schemaUsername = schemaUsername;
+		this.schemaPassword = schemaPassword;
+		this.autoUpdate = autoUpdate;
+	}
+
+}

--- a/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/domain/Tenant.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/domain/Tenant.java
@@ -5,61 +5,123 @@
  */
 package org.mifosplatform.infrastructure.core.domain;
 
-public class Tenant {
+import java.util.Date;
 
-    private final Long id;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+import org.apache.commons.lang.StringUtils;
+import org.mifosplatform.infrastructure.core.api.JsonCommand;
+import org.springframework.data.jpa.domain.AbstractPersistable;
+
+@Entity
+@Table(schema="`mifosplatform-tenants`", name = "tenants")
+public class Tenant extends AbstractPersistable<Long> {
+
+	@Column(name="identifier", nullable=false, length=100, unique=true)
+	private final String identifier;
+	
+	@Column(name="name", nullable=false, length=100)
     private final String name;
+	
+	@Column(name="schema_name", nullable=false, length=100, unique=true)
     private final String schemaName;
-    private final String schemaServer;
-    private final String schemaServerPort;
-    private final String schemaUsername;
-    private final String schemaPassword;
+	
+	@Column(name="timezone_id", nullable=false, length=100)
     private final String timezoneId;
-    
-
-    public Tenant(final Long id, final String name, final String schemaName, final String schemaServer,
-            final String schemaServerPort, final String schemaUsername, final String schemaPassword, String timezoneId) {
-        this.id = id;
-        this.name = name;
-        this.schemaName = schemaName;
-        this.schemaServer = schemaServer;
-        this.schemaServerPort = schemaServerPort;
-        this.schemaUsername = schemaUsername;
-        this.schemaPassword = schemaPassword;
-        this.timezoneId = timezoneId;
+	
+	@Column(name="country_id", nullable=true)
+    private final Integer countryId;
+	
+	@Column(name="joined_date", nullable=true)
+    private final Date joinedDate;
+	
+	@Column(name="created_date", nullable=true)
+    private final Date createdDate;
+	
+	@Column(name="lastmodified_date", nullable=true)
+    private final Date lastModified;
+	
+	@Column(name="schema_server", nullable=false, length=100)
+    private final String schemaServer;
+	
+	@Column(name="schema_server_port", nullable=false, length=10)
+    private final String schemaServerPort;
+	
+	@Column(name="schema_username", nullable=false, length=100)
+	private final String schemaUsername;
+	
+	@Column(name="schema_password", nullable=false, length=100)
+    private final String schemaPassword;
+	
+	@Column(name="auto_update", nullable=true)
+	private final Short autoUpdate;
+	
+	public String databaseURL() {
         
+		String url = new StringBuilder("jdbc:mysql://").append(schemaServer).append(':').append(schemaServerPort).append('/')
+                .append(schemaName).toString();
+        return url;
     }
-
-    public Long getId() {
-        return id;
+	
+	public String getSchemaName() {
+		
+		return schemaName;
+	}
+	
+	public String getSchemaUsername() {
+		
+		return schemaUsername;
+	}
+	
+	public String getSchemaPassword() {
+		
+		return schemaPassword;
+	}
+	
+	public static Tenant fromJson(final JsonCommand command) {
+		
+		final String identifier = command.stringValueOfParameterNamed("identifier");
+		final String name = command.stringValueOfParameterNamed("name");
+		final String schemaName = command.stringValueOfParameterNamed("schemaName");
+		final String timezoneId = command.stringValueOfParameterNamed("timezoneId");
+		final Integer countryId = command.integerValueOfParameterNamed("countryId");
+		final Date joinedDate = command.DateValueOfParameterNamed("joinedDate");
+		final Date createdDate = command.DateValueOfParameterNamed("createdDate");
+		final Date lastModified = command.DateValueOfParameterNamed("lastModified");
+		final String schemaServer = command.stringValueOfParameterNamed("schemaServer");
+		final String schemaServerPort = command.stringValueOfParameterNamed("schemaServerPort");
+		final String schemaUsername = command.stringValueOfParameterNamed("schemaUsername");
+		final String schemaPassword = command.stringValueOfParameterNamed("schemaPassword");
+		final Short autoUpdate = Short.valueOf(command.stringValueOfParameterNamed("autoUpdate"));
+		
+		return new Tenant(identifier, name, schemaName, timezoneId, countryId,
+				joinedDate, createdDate, lastModified, schemaServer,
+				schemaServerPort, schemaUsername, schemaPassword, autoUpdate);
+	}
+	
+	public Tenant(final String identifier, final String name,
+			final String schemaName, final String timezoneId,
+			final Integer countryId, final Date joinedDate,
+			final Date createdDate, final Date lastModified,
+			final String schemaServer, final String schemaServerPort,
+			final String schemaUsername, final String schemaPassword,
+			final Short autoUpdate) {
+        
+		this.identifier = StringUtils.defaultIfEmpty(identifier, null);
+        this.name = StringUtils.defaultIfEmpty(name, null);
+        this.schemaName = StringUtils.defaultIfEmpty(schemaName, null);
+        this.timezoneId = StringUtils.defaultIfEmpty(timezoneId, null);
+        this.countryId = countryId;
+        this.joinedDate = joinedDate;
+        this.createdDate = createdDate;
+        this.lastModified = lastModified;
+        this.schemaServer = StringUtils.defaultIfEmpty(schemaServer, null);
+        this.schemaServerPort = StringUtils.defaultIfEmpty(schemaServerPort, null);
+        this.schemaUsername = StringUtils.defaultIfEmpty(schemaUsername, null);
+        this.schemaPassword = StringUtils.defaultIfEmpty(schemaPassword, null);
+        this.autoUpdate = autoUpdate;
     }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getSchemaName() {
-        return schemaName;
-    }
-
-    public String getSchemaServer() {
-        return schemaServer;
-    }
-
-    public String getSchemaServerPort() {
-        return schemaServerPort;
-    }
-
-    public String getSchemaUsername() {
-        return schemaUsername;
-    }
-
-    public String getSchemaPassword() {
-        return schemaPassword;
-    }
-    
-    public String getTimezoneId() {
-        return timezoneId;
-    }
-      
+	
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/domain/TenantRepository.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/domain/TenantRepository.java
@@ -1,0 +1,8 @@
+package org.mifosplatform.infrastructure.core.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface TenantRepository extends JpaRepository<Tenant, Long>, JpaSpecificationExecutor<Tenant> {
+	// no added behaviour
+}

--- a/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/handler/CreateTenantCommandHandler.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/handler/CreateTenantCommandHandler.java
@@ -1,0 +1,27 @@
+package org.mifosplatform.infrastructure.core.handler;
+
+import org.mifosplatform.commands.handler.NewCommandSourceHandler;
+import org.mifosplatform.infrastructure.core.api.JsonCommand;
+import org.mifosplatform.infrastructure.core.data.CommandProcessingResult;
+import org.mifosplatform.infrastructure.core.service.TenantWritePlatformService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CreateTenantCommandHandler implements NewCommandSourceHandler {
+	
+	private final TenantWritePlatformService writePlatformService;
+
+    @Autowired
+    public CreateTenantCommandHandler(final TenantWritePlatformService writePlatformService) {
+        this.writePlatformService = writePlatformService;
+    }
+
+    @Transactional
+    @Override
+    public CommandProcessingResult processCommand(final JsonCommand command) {
+
+        return this.writePlatformService.createTenant(command);
+    }
+}

--- a/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/serialization/TenantCommandFromApiJsonDeserializer.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/serialization/TenantCommandFromApiJsonDeserializer.java
@@ -1,0 +1,49 @@
+package org.mifosplatform.infrastructure.core.serialization;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.mifosplatform.infrastructure.core.data.ApiParameterError;
+import org.mifosplatform.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.google.gson.reflect.TypeToken;
+
+@Component
+public class TenantCommandFromApiJsonDeserializer {
+	
+	private final Set<String> supportedParameters = new HashSet<String>(
+			Arrays.asList("identifier", "name", "schemaName", "timezoneId",
+					"countryId", "joinedDate", "createdDate",
+					"lastmodifiedDate", "schemaServer", "schemaServerPort",
+					"schemaUsername", "schemaPassword", "autoUpdate"));
+	
+	private final FromJsonHelper fromApiJsonHelper;
+	
+	@Autowired
+	public TenantCommandFromApiJsonDeserializer(final FromJsonHelper fromApiJsonHelper) {
+		
+		this.fromApiJsonHelper = fromApiJsonHelper;
+	}
+	
+	public void validateForCreate(final String json) {
+		
+        final Type typeOfMap = new TypeToken<Map<String, Object>>() {}.getType();
+        fromApiJsonHelper.checkForUnsupportedParameters(typeOfMap, json, supportedParameters);
+
+        final List<ApiParameterError> dataValidationErrors = new ArrayList<ApiParameterError>();
+		
+		throwExceptionIfValidationWarningsExist(dataValidationErrors);
+	}
+	
+	private void throwExceptionIfValidationWarningsExist(final List<ApiParameterError> dataValidationErrors) {
+        if (!dataValidationErrors.isEmpty()) { throw new PlatformApiDataValidationException("validation.msg.validation.errors.exist",
+                "Validation errors exist.", dataValidationErrors); }
+    }
+}

--- a/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/service/TenantWritePlatformService.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/service/TenantWritePlatformService.java
@@ -1,0 +1,9 @@
+package org.mifosplatform.infrastructure.core.service;
+
+import org.mifosplatform.infrastructure.core.api.JsonCommand;
+import org.mifosplatform.infrastructure.core.data.CommandProcessingResult;
+
+public interface TenantWritePlatformService {
+
+	CommandProcessingResult createTenant(JsonCommand command);
+}

--- a/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/service/TenantWritePlatformServiceJpaRepositoryImpl.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/service/TenantWritePlatformServiceJpaRepositoryImpl.java
@@ -1,0 +1,94 @@
+package org.mifosplatform.infrastructure.core.service;
+
+import javax.sql.DataSource;
+
+import org.mifosplatform.infrastructure.core.api.JsonCommand;
+import org.mifosplatform.infrastructure.core.data.CommandProcessingResult;
+import org.mifosplatform.infrastructure.core.data.CommandProcessingResultBuilder;
+import org.mifosplatform.infrastructure.core.domain.Tenant;
+import org.mifosplatform.infrastructure.core.domain.TenantRepository;
+import org.mifosplatform.infrastructure.core.exception.PlatformDataIntegrityException;
+import org.mifosplatform.infrastructure.core.serialization.TenantCommandFromApiJsonDeserializer;
+import org.mifosplatform.infrastructure.security.service.PlatformSecurityContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import com.googlecode.flyway.core.Flyway;
+
+@Service
+public class TenantWritePlatformServiceJpaRepositoryImpl implements TenantWritePlatformService {
+
+	private final static Logger logger = LoggerFactory.getLogger(TenantWritePlatformServiceJpaRepositoryImpl.class);
+	
+	private final PlatformSecurityContext context;
+	private final TenantCommandFromApiJsonDeserializer fromApiJsonDeserializer;
+	private final TenantRepository tenantRepository;
+	private final JdbcTemplate jdbcTemplate;
+	
+	@Autowired
+	public TenantWritePlatformServiceJpaRepositoryImpl(final PlatformSecurityContext context,
+			final TenantCommandFromApiJsonDeserializer fromApiJsonDeserializer, final TenantRepository tenantRepository,
+			@Qualifier("tenantDataSourceJndi") final DataSource dataSource) {
+		
+		this.context = context;
+		this.fromApiJsonDeserializer = fromApiJsonDeserializer;
+		this.tenantRepository = tenantRepository;
+		this.jdbcTemplate = new JdbcTemplate(dataSource);
+	}
+	
+	@Override
+	public CommandProcessingResult createTenant(JsonCommand command) {
+		
+		try {
+			context.authenticatedUser();
+			
+			this.fromApiJsonDeserializer.validateForCreate(command.json());
+			
+			final Tenant tenant = Tenant.fromJson(command);
+			
+			this.tenantRepository.save(tenant);
+			
+			createTenantDatabase(tenant);
+			
+			return new CommandProcessingResultBuilder().withCommandId(command.commandId()).withEntityId(tenant.getId()).build();
+		} catch (DataIntegrityViolationException dve) {
+			
+			handleTenantDataIntegrityIssues(command, dve);
+			return CommandProcessingResult.empty();
+		}
+	}
+	
+	private void createTenantDatabase(Tenant tenant) {
+		
+		jdbcTemplate.execute("CREATE DATABASE `" + tenant.getSchemaName() + "`");
+		
+		Flyway flyway = new Flyway();
+		flyway.setDataSource(tenant.databaseURL(), tenant.getSchemaUsername(), tenant.getSchemaPassword());
+		flyway.setLocations("sql");
+		flyway.migrate();
+	}
+	
+	private void handleTenantDataIntegrityIssues(final JsonCommand command, DataIntegrityViolationException dve) {
+
+        Throwable realCause = dve.getMostSpecificCause();
+        if (realCause.getMessage().contains("tenant_identifier")) {
+            final String identifier = command.stringValueOfParameterNamed("identifier");
+            throw new PlatformDataIntegrityException("error.msg.tenant.duplicate.identifier", "A tenant with the identifier '" + identifier
+                    + "' already exists", "identifier", identifier);
+        } else if (realCause.getMessage().contains("tenant_schema_name")) {
+            final String schemaName = command.stringValueOfParameterNamed("schema_name");
+            throw new PlatformDataIntegrityException("error.msg.tenant.duplicate.schema.name", "A tenant with the schema name '" + schemaName
+                    + "' already exists", "schema_name", schemaName);
+        }
+
+        logger.error(dve.getMessage(), dve);
+        throw new PlatformDataIntegrityException("error.msg.tenant.unknown.data.integrity.issue",
+                "Unknown data integrity issue with resource: " + realCause.getMessage());
+    }
+
+}


### PR DESCRIPTION
Added the ability to create new tenants by passing correct arguments to /tenants. After adding a new entry to `mifosplatform-tenants`.`tenants`, a new database is initialized and `flyway.migrate()` is called.

A new permission (`Tenant`) under the Authorisation tab has been added.

Example API call:

```
var tenantObject = new Object();
tenantObject.identifier = "new";
tenantObject.name = "New Tenant";
tenantObject.schemaName = "mifostenant-new";
tenantObject.timezoneId = "Asia/Kolkata";
tenantObject.countryId = null;
tenantObject.joinedDate = null;
tenantObject.createdDate = null;
tenantObject.lastmodifiedDate = null;
tenantObject.schemaServer = "localhost";
tenantObject.schemaServerPort = "3306";
tenantObject.schemaUsername = "root";
tenantObject.schemaPassword = "mysql";
tenantObject.autoUpdate = 1;

var tenantObjectStr = JSON.stringify(tenantObject);

executeAjaxRequest("tenants", "POST", tenantObjectStr, successFunction, failureFunction);
```
