### PR TITLE
quick fix for enabling mifosx-443 enable separate datatables for centers

### DIFF
--- a/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/serialization/DatatableCommandFromApiJsonDeserializer.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/serialization/DatatableCommandFromApiJsonDeserializer.java
@@ -47,7 +47,7 @@ public class DatatableCommandFromApiJsonDeserializer {
     private final Set<String> supportedParametersForDropColumns = new HashSet<String>(Arrays.asList(
     		"name"));
     private final Object[] supportedColumnTypes = { "String", "Number", "Decimal", "Date", "Text", "Dropdown" };
-    private final Object[] supportedApptableNames = { "m_loan", "m_savings_account", "m_client", "m_group", "m_office", "m_savings_product", "m_product_loan" };
+    private final Object[] supportedApptableNames = { "m_loan", "m_savings_account", "m_client", "m_group", "m_center", "m_office", "m_savings_product", "m_product_loan" };
 
     private final FromJsonHelper fromApiJsonHelper;
 


### PR DESCRIPTION
@johnw65   @keithwoodlock 

This is a quick fix for enabling separate datatables for centers (as per GK requirements). I will come back to this issue later for a more generic approach for having different data-tables for different entities stored in the m_group tables
