### PR TITLE
super minor: Utils.convertDateToURLFormat exception propagation (or just delete)

### DIFF
--- a/mifosng-provider/src/integrationTest/java/org/mifosplatform/integrationtests/common/Utils.java
+++ b/mifosng-provider/src/integrationTest/java/org/mifosplatform/integrationtests/common/Utils.java
@@ -6,6 +6,8 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import java.util.Random;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.conn.HttpHostConnectException;
 
@@ -13,11 +15,6 @@ import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.path.json.JsonPath;
 import com.jayway.restassured.specification.RequestSpecification;
 import com.jayway.restassured.specification.ResponseSpecification;
-
-import java.lang.System;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Random;
 
 @SuppressWarnings("unchecked")
 public class Utils {


### PR DESCRIPTION
super super minor, just somethingn I stumbled over.. see attached two commits.
