### PR TITLE
Added missing Braces for create holidays in API doc

### DIFF
--- a/api-docs/apiLive.htm
+++ b/api-docs/apiLive.htm
@@ -9158,8 +9158,8 @@ Request Body:
 "toDate": "25 October 2013",
 "repaymentsRescheduledTo": "26 October 2013",
 "offices": [
-	"officeId":"1",
-	"officeId":"2"
+	{"officeId":"1"},
+	{"officeId":"2"}
 ]
 }
 				</code>


### PR DESCRIPTION
Vishwas,

Updated the holidays api doc with missing Braces in create holiday JSON string.

Regards
Ashok
