### PR TITLE
GSoC UGD API Doc proposal (for discussion & review)

### DIFF
--- a/api-docs/apiLive.htm
+++ b/api-docs/apiLive.htm
@@ -19863,8 +19863,11 @@ GET https://DomainName/api/v1/search?query=000000111
 		<div class="method-section">
 			<div class="method-description">
 				<h3>Templates</h3>
-				<p>Templates are for custom document generation.</p>
-				<p>Templates can be assigned to an entity like <b>client</b> or <b>loan</b> and be of a typ like <b>document</b> .</p>
+				<p>Templates are used for end-user features such as custom user defined document generation (AKA UGD).  They are based on <a href="http://mustache.github.io/">{{ moustache }} templates</a>. Think of them as a sort of built-in "mail merge" functionality.</p>
+
+				<p>User Generated Documents (and other types of templates) can aggregate data from several Mifos X back-end API calls via <b>mappers</b>.  Mappers can even access non-Mifos X REST services from other servers.  UGDs can render such data in tables, show images, etc. <i>TBD: Please have a look at some of the Example UGDs included in Mifos X (or <a href="https://mifosforge.jira.com/wiki/display/RES/UGD_FinalDoc">the Wiki page</a>, for now.).</i></p>
+
+				<p>Templates can be assigned to an entity like <b>client</b> or <b>loan</b> and be of a typ like <b>document</b>.  The entity and type of a template is only there for the convenience of user agents (UIs), in order to know where to show templates for the user (i.e. which tab).  The Template Engine back-end runner does not actually need this metadata.</p>
 				<table class=matrixHeading>
 					<tr class="matrixHeadingBG">
 						<td><div class="mifosXHeading2">Field Descriptions</div></td>
@@ -19963,7 +19966,7 @@ GET https://DomainName/api/v1/templates/template
   "name": "Test",
   "entity": "loan",
   "type": "Document",
-  "text": "This is a text with a {{mustache.tag}} ",
+  "text": "This is a loan for {{loan.clientName}}",
   "mappers": [
     {
     "mapperorder": 0,
@@ -20007,7 +20010,7 @@ Request Body:
   "name": "Test",
   "entity": "loan",
   "type": "Document",
-  "text": "This is a text with a {{mustache.tag}} ",
+  "text": "This is a loan for {{loan.clientName}}",
   "mappers": [
     {
       "mapperorder": 0,
@@ -20078,7 +20081,7 @@ GET https://DomainName/api/v1/templates
     "name": "Test",
     "entity": "loan",
     "type": "Document",
-    "text": "This is a text with a {{mustache.tag}} ",
+    "text": "This is a loan for {{loan.clientName}}",
     "mappers": [
       {
         "mapperorder": 0,
@@ -20111,7 +20114,7 @@ GET https://DomainName/api/v1/templates/{Id}
   "name": "Test",
   "entity": "loan",
   "type": "Document",
-  "text": "This is a text with a {{mustache.tag}} ",
+  "text": "This is a loan for {{loan.clientName}}",
   "mappers": [
     {
       "mapperorder": 0,
@@ -20144,7 +20147,7 @@ Request Body:
   "name": "Test",
   "entity": "loan",
   "type": "Document",
-  "text": "This is a text with a {{mustache.tag}} ",
+  "text": "This is a loan for {{loan.clientName}}",
   "mappers": [
     {
       "mapperorder": 0,


### PR DESCRIPTION
Hi guys, 

here is finally the PR for the GSoC UGD API Doc... basically https://github.com/weigel/mifosx/commit/b2e6054053d8576e493860e3fbfd1c7b9a52e90e from Andreas, plus some additional intro. blurb and minor change from me. This is for your kind consideration, discussion & review - unless you can pull as-is. Points in particular:
- it occurred to me only on reading this API Doc, a little late admittedly, that the "Template" terminology we've chosen for the back-end of UGD overlaps with what you call Template in the existing API - which has nothing to do with this of course.. this could be confusing to users? It's perhaps a little late to change that.. opinions? Concrete suggestions how to (re)name which? - Maybe you could pull this doc in as-is into develop so that at least there is SOME doc - and then have a separate thread on renaming.. what - entire API, URLs, packages, and doc? I won't have time for this, but could pick it up with Andreas later - depending on how you feel about this double use of "Template" in Mifos X. If it's a non-issue for you, please say so and let's ignore it.
- how do you make our new section show up on top ribbon and in bottom Beta API Matrix? May be trivial - I simply haven't look closely. Will you do that?

Best,
Michael
