### PR TITLE
MIFOSX-873 #comment fixed for getting client by officeId,firstName,lastName,displayName

### DIFF
--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/client/service/ClientReadPlatformServiceImpl.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/client/service/ClientReadPlatformServiceImpl.java
@@ -150,7 +150,7 @@ public class ClientReadPlatformServiceImpl implements ClientReadPlatformService 
         }
 
         if (officeId != null) {
-            extraCriteria += " and office_id = " + officeId;
+            extraCriteria += " and c.office_id = " + officeId;
         }
 
         if (externalId != null) {
@@ -158,16 +158,16 @@ public class ClientReadPlatformServiceImpl implements ClientReadPlatformService 
         }
 
         if (displayName != null) {
-            extraCriteria += " and concat(ifnull(firstname, ''), if(firstname > '',' ', '') , ifnull(lastname, '')) like "
+            extraCriteria += " and concat(ifnull(c.firstname, ''), if(c.firstname > '',' ', '') , ifnull(c.lastname, '')) like "
                     + ApiParameterHelper.sqlEncodeString(displayName);
         }
 
         if (firstname != null) {
-            extraCriteria += " and firstname like " + ApiParameterHelper.sqlEncodeString(firstname);
+            extraCriteria += " and c.firstname like " + ApiParameterHelper.sqlEncodeString(firstname);
         }
 
         if (lastname != null) {
-            extraCriteria += " and lastname like " + ApiParameterHelper.sqlEncodeString(lastname);
+            extraCriteria += " and c.lastname like " + ApiParameterHelper.sqlEncodeString(lastname);
         }
 
         if (searchParameters.isScopedByOfficeHierarchy()) {


### PR DESCRIPTION
In version 1.17 when extra criteria is edit to get client just throwing Internal server error for extra criteria like officeId,firstName,lastName,displayName.
The Reason for the issue are these both column present in client table and office table when these column are used in the search condition with out table name then query fails because of ambiguity the same is fixed in this pull request by adding explicitly table name to the search criteria column name.
