### PR TITLE
[MIFOSX-875] Unknown Data Integrity Issue while adding duplicate mobileNo when creating new client has been fixed

### DIFF
--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/client/service/ClientWritePlatformServiceJpaRepositoryImpl.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/client/service/ClientWritePlatformServiceJpaRepositoryImpl.java
@@ -125,6 +125,10 @@ public class ClientWritePlatformServiceJpaRepositoryImpl implements ClientWriteP
             final String accountNo = command.stringValueOfParameterNamed("accountNo");
             throw new PlatformDataIntegrityException("error.msg.client.duplicate.accountNo", "Client with accountNo `" + accountNo
                     + "` already exists", "accountNo", accountNo);
+        } else if (realCause.getMessage().contains("mobile_no")) {
+            final String mobileNo = command.stringValueOfParameterNamed("mobileNo");
+            throw new PlatformDataIntegrityException("error.msg.client.duplicate.mobileNo", "Client with mobileNo `" + mobileNo
+                    + "` already exists", "mobileNo", mobileNo);
         }
 
         logAsErrorUnexpectedDataIntegrityException(dve);


### PR DESCRIPTION
[MIFOSX-875] Added new feature, to throw exception saying that Client mobile number already exist, instead of throwing Unknown Data Integrity error,  when user try to attach duplicate mobile number while creating client.
