### PR TITLE
MIFOSX-896 - added permission for 'savingsaccountcharge' endpoint - simple SQL insert

### DIFF
--- a/mifosng-db/migrations/core_db/V142_read_savingsaccount_charge_permission.sql
+++ b/mifosng-db/migrations/core_db/V142_read_savingsaccount_charge_permission.sql
@@ -1,0 +1,1 @@
+insert into `m_permission` (`grouping`, `code`, `entity_name`, `action_name`, `can_maker_checker`) VALUES ('portfolio', 'READ_SAVINGSACCOUNTCHARGE', 'SAVINGSACCOUNTCHARGE', 'READ', 0);


### PR DESCRIPTION
The permission required to read the savings account charge was never added to the "m_permission" table. Missing permission - READ_SAVINGSACCOUNTCHARGE
