### PR TITLE
MIFOSX-900 - Refuse deactivating charges that are currently in use

### DIFF
--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/charge/exception/ChargeCannotBeUpdatedException.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/charge/exception/ChargeCannotBeUpdatedException.java
@@ -1,0 +1,13 @@
+package org.mifosplatform.portfolio.charge.exception;
+
+import org.mifosplatform.infrastructure.core.exception.AbstractPlatformDomainRuleException;
+
+public class ChargeCannotBeUpdatedException extends AbstractPlatformDomainRuleException {
+
+    public ChargeCannotBeUpdatedException(final String globalisationMessageCode, final String defaultUserMessage,
+            final Object... defaultUserMessageArgs) {
+
+        super(globalisationMessageCode, defaultUserMessage, defaultUserMessageArgs);
+    }
+
+}


### PR DESCRIPTION
This pull request fixes 2 bugs:
- When deleting charges for Savings no check was done if it was actually associated to existing accounts.
- When de-activating charges no check was done if it was actually associated with any existing Loan or Savings products. 

Both issues caused some integrity issues in the API responses on the respective pages.
