### PR TITLE
MIFOSX-1014 - Fixed MakerChecker for Loans,Savings and possibly many mor...

### DIFF
--- a/mifosng-provider/src/main/java/org/mifosplatform/commands/domain/CommandSource.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/commands/domain/CommandSource.java
@@ -183,4 +183,41 @@ public class CommandSource extends AbstractPersistable<Long> {
     public Long getProductId() {
         return this.productId;
     }
+
+    /**
+     * @return the clientId
+     */
+    public Long getClientId() {
+        return clientId;
+    }
+
+    /**
+     * @return the groupId
+     */
+    public Long getGroupId() {
+        return groupId;
+    }
+
+    /**
+     * @return the loanId
+     */
+    public Long getLoanId() {
+        return loanId;
+    }
+
+    /**
+     * @return the officeId
+     */
+    public Long getOfficeId() {
+        return officeId;
+    }
+
+    /**
+     * @return the savingsId
+     */
+    public Long getSavingsId() {
+        return savingsId;
+    }
+    
+    
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/commands/domain/CommandWrapper.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/commands/domain/CommandWrapper.java
@@ -37,6 +37,13 @@ public class CommandWrapper {
         return new CommandWrapper(commandId, actionName, entityName, resourceId, subresourceId, resourceGetUrl, productId);
     }
 
+    
+    public static CommandWrapper fromExistingCommand(final Long commandId, final String actionName, final String entityName,
+            final Long resourceId, final Long subresourceId, final String resourceGetUrl, final Long productId,
+            final Long officeId, final Long groupId, final Long clientId, final Long loanId, final Long savingsId) {
+        return new CommandWrapper(commandId, actionName, entityName, resourceId, subresourceId, resourceGetUrl, productId);
+    }
+    
     private CommandWrapper(final Long commandId, final String actionName, final String entityName, final Long resourceId,
             final Long subresourceId, final String resourceGetUrl, final Long productId) {
         this.commandId = commandId;
@@ -84,6 +91,30 @@ public class CommandWrapper {
         this.templateId = templateId;
     }
 
+        public CommandWrapper(final Long commandId, final String actionName, final String entityName,
+            final Long resourceId, final Long subresourceId, final String resourceGetUrl, final Long productId,
+            final Long officeId, final Long groupId, final Long clientId, final Long loanId, final Long savingsId) {
+        
+        this.commandId = commandId;
+        this.officeId = officeId;
+        this.groupId = groupId;
+        this.clientId = clientId;
+        this.loanId = loanId;
+        this.savingsId = savingsId;
+        this.actionName = actionName;
+        this.entityName = entityName;
+        this.taskPermissionName = actionName + "_" + entityName;
+        this.entityId = resourceId;
+        this.subentityId = subresourceId;
+        this.codeId = null;
+        this.supportedEntityType = null;
+        this.supportedEntityId = null;
+        this.href = resourceGetUrl;
+        this.json = null;
+        this.transactionId = null;
+        this.productId = productId;
+    }
+    
     public Long commandId() {
         return this.commandId;
     }

--- a/mifosng-provider/src/main/java/org/mifosplatform/commands/service/PortfolioCommandSourceWritePlatformServiceImpl.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/commands/service/PortfolioCommandSourceWritePlatformServiceImpl.java
@@ -86,12 +86,14 @@ public class PortfolioCommandSourceWritePlatformServiceImpl implements Portfolio
 
         final CommandWrapper wrapper = CommandWrapper.fromExistingCommand(makerCheckerId, commandSourceInput.getActionName(),
                 commandSourceInput.getEntityName(), commandSourceInput.resourceId(), commandSourceInput.subresourceId(),
-                commandSourceInput.getResourceGetUrl(), commandSourceInput.getProductId());
-
+                commandSourceInput.getResourceGetUrl(), commandSourceInput.getProductId(), commandSourceInput.getOfficeId(), 
+                commandSourceInput.getGroupId(), commandSourceInput.getClientId(), commandSourceInput.getLoanId(), commandSourceInput.getSavingsId());
         final JsonElement parsedCommand = this.fromApiJsonHelper.parse(commandSourceInput.json());
         final JsonCommand command = JsonCommand.fromExistingCommand(makerCheckerId, commandSourceInput.json(), parsedCommand,
                 this.fromApiJsonHelper, commandSourceInput.getEntityName(), commandSourceInput.resourceId(),
-                commandSourceInput.subresourceId(), commandSourceInput.getResourceGetUrl(), commandSourceInput.getProductId());
+                commandSourceInput.subresourceId(), commandSourceInput.getGroupId(), commandSourceInput.getClientId(), commandSourceInput.getLoanId(),
+                commandSourceInput.getSavingsId(), commandSourceInput.getResourceGetUrl(), commandSourceInput.getProductId());
+        
 
         final boolean makerCheckerApproval = true;
         return this.processAndLogCommandService.processAndLogCommand(wrapper, command, makerCheckerApproval);

--- a/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/api/JsonCommand.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/core/api/JsonCommand.java
@@ -67,6 +67,13 @@ public final class JsonCommand {
                 null, null, null, null, null, null, url, productId);
     }
 
+    public static JsonCommand fromExistingCommand(final Long commandId, final String jsonCommand, final JsonElement parsedCommand,
+            final FromJsonHelper fromApiJsonHelper, final String entityName, final Long resourceId, final Long subresourceId,
+            final Long groupId, final Long clientId, final Long loanId, final Long savingsId,final String url, final Long productId) {
+        return new JsonCommand(commandId, jsonCommand, parsedCommand, fromApiJsonHelper, entityName, resourceId, subresourceId, groupId, clientId,
+                loanId, savingsId, null, null, null, null, url, productId);
+    }
+    
     public JsonCommand(final Long commandId, final String jsonCommand, final JsonElement parsedCommand,
             final FromJsonHelper fromApiJsonHelper, final String entityName, final Long resourceId, final Long subresourceId,
             final Long groupId, final Long clientId, final Long loanId, final Long savingsId, final Long codeId,
@@ -90,6 +97,7 @@ public final class JsonCommand {
         this.url = url;
         this.productId = productId;
     }
+    
 
     public String json() {
         return this.jsonCommand;


### PR DESCRIPTION
Hi Vishwas,
During routine tests we found out that the maker-checker features were seriously broken. Things like Loan Repayments, Adjustments of Payments, waivers etc could not be maker-checkered without throwing 500 errors because the correct fields (loanId, SavingsId for instance) were not set as part of the new command. Has now been fixed. We will cherry-pick for our own production version for now so can go along in next release.

Sander
