### PR TITLE
JobRegisterServiceImpl error logging improvement 

### DIFF
--- a/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/jobs/service/JobRegisterServiceImpl.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/jobs/service/JobRegisterServiceImpl.java
@@ -108,8 +108,12 @@ public class JobRegisterServiceImpl implements JobRegisterService {
             }
 
         } catch (final Exception e) {
-            throw new PlatformInternalServerException("error.msg.sheduler.job.execution.failed", "Job execution failed for job with id:"
-                    + scheduledJobDetail.getId(), scheduledJobDetail.getId());
+			final String msg = "Job execution failed for job with id:"
+					+ scheduledJobDetail.getId();
+			logger.error(msg, e);
+			throw new PlatformInternalServerException(
+					"error.msg.sheduler.job.execution.failed", msg,
+					scheduledJobDetail.getId());
         }
 
     }
@@ -214,6 +218,9 @@ public class JobRegisterServiceImpl implements JobRegisterService {
             scheduledJobDetails.updateNextRunTime(null);
             final String stackTrace = getStackTraceAsString(throwable);
             scheduledJobDetails.updateErrorLog(stackTrace);
+			logger.error(
+					"Could not schedule job: "
+							+ scheduledJobDetails.getJobName(), throwable);
         }
         scheduledJobDetails.updateCurrentlyRunningStatus(false);
     }


### PR DESCRIPTION
Logging 2x, for otherwise silent failures in a) initial loadAllJobs(), and b) subsequent manual executeJob(). -logger.error() needed to see these problems, because these errors otherwise do not seem to appear in (Console) log - upstream container (Tomcat) seems to swallow them.

I'll create a JIRA describing background.
