### PR TITLE
Improved the logging of test failures on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,8 @@ jdk:
 script: ./travis_build.sh
 notifications:
   email: true
+# This is so that the Gradle output is readable on the Travis web console
+# @see http://stackoverflow.com/questions/17942819/how-can-i-get-clean-gradle-output-on-travis-ci
+# @see http://gradle.1045684.n5.nabble.com/Plain-console-output-td5710237.html
+env:
+  - TERM=dumb

--- a/travis_build.sh
+++ b/travis_build.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 cd mifosng-provider
-./gradlew clean test
+# NOTE: The --info, while quite a bit more verbose, is VERY useful to understand failures on Travis,
+# where you do not have access to any files like build/reports/tests/index.html, only the Console. 
+# @see http://mrhaki.blogspot.ch/2013/05/gradle-goodness-show-more-information.html
+# @see http://forums.gradle.org/gradle/topics/whats_new_in_gradle_1_1_test_logging for alternative 
+./gradlew --info clean test


### PR DESCRIPTION
Travis CI output like this https://travis-ci.org/openMF/mifosx/builds/30501274 is quite useless (just name of failing test and exception's getMessage()), while e.g. https://travis-ci.org/openMF/mifosx/builds/30506366 which was built including this change is MUCH clearer (full stack trace, and more readable as no more funny characters on Travis non-ANSI TERM).

This PR improves that.
