### PR TITLE
Fix Flyway Core vs. Maven plug-in mess

### DIFF
--- a/mifosng-provider/build.gradle
+++ b/mifosng-provider/build.gradle
@@ -138,7 +138,7 @@ dependencies {
 	            [group: 'com.lowagie', name: 'itext', version: '2.1.7'],
 	            [group: 'com.lowagie', name: 'itext-rtf', version: '2.1.7'],
 				[group: 'org.mnode.ical4j', name: 'ical4j', version: '1.0.4'],
-                [group: 'com.googlecode.flyway', name: 'flyway-maven-plugin', version: '2.1.1'],
+	            [group: 'com.googlecode.flyway', name: 'flyway-core', version: '2.1.1'],
                 [group: 'org.quartz-scheduler', name: 'quartz', version: '2.1.7'],
                 [group: 'com.amazonaws', name: 'aws-java-sdk', version: '1.2.1'],
                 [group: 'net.sf.ehcache', name: 'ehcache', version: '2.7.2'],


### PR DESCRIPTION
Fixes build.gradle having had the Flyway Maven plug-in instead of flyway-core.

Other than just “not being nice & proper & correct”, this mistake leads to a lot of Maven JARs unnecessarily ending up in the WAR and on the classpath (incl. e.g. in-IDE),  which in turn led to the errors below due to a slfj4j version mess (when using the upcoming  upcoming sweet new simple MifosWithDBServerApplication main()

SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/home/vorburger/.gradle/caches/artifacts-26/filestore/ch.qos.logback/logback-classic/1.1.2/jar/b316e9737eea25e9ddd6d88eaeee76878045c6b2/logback-classic-1.1.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/home/vorburger/.gradle/caches/artifacts-26/filestore/org.slf4j/slf4j-nop/1.5.3/jar/36a3c886235cddd05e55a979cef549196740231a/slf4j-nop-1.5.3.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/home/vorburger/.gradle/caches/artifacts-26/filestore/org.slf4j/slf4j-jdk14/1.5.6/jar/cc383fbd07dd1826bbcba1b907bbdc0b5be627f1/slf4j-jdk14-1.5.6.jar!/org/slf4j/impl/StaticLoggerBinder.class]g
SLF4J: Found binding in [jar:file:/home/vorburger/.m2/repository/ch/qos/logback/logback-classic/1.1.2/logback-classic-1.1.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.

java.lang.AbstractMethodError: org.slf4j.impl.JDK14LoggerAdapter.log(Lorg/slf4j/Marker;Ljava/lang/String;ILjava/lang/String;[Ljava/lang/Object;Ljava/lang/Throwable;)V at org.apache.commons.logging.impl.SLF4JLocationAwareLog.info(SLF4JLocationAwareLog.java:159)
