### PR TITLE
Fix for start-up problem if WAR is NOT unpacked

### DIFF
--- a/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/jobs/annotation/CronMethodParser.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/infrastructure/jobs/annotation/CronMethodParser.java
@@ -60,7 +60,8 @@ public class CronMethodParser {
             throws IOException {
         final String basePackagePath = ClassUtils.convertClassNameToResourcePath(new StandardEnvironment()
                 .resolveRequiredPlaceholders(SEARCH_PACKAGE));
-        final String packageSearchPath = ResourcePatternResolver.CLASSPATH_ALL_URL_PREFIX + basePackagePath + "/" + RESOURCE_PATTERN;
+        String packageSearchPath = ResourcePatternResolver.CLASSPATH_ALL_URL_PREFIX + basePackagePath + "/" + RESOURCE_PATTERN;
+        packageSearchPath = packageSearchPath.replace("//", "/"); // else it doesn't work if *.class are in WAR!!
         final Resource[] resources = resourcePatternResolver.getResources(packageSearchPath);
         for (final Resource resource : resources) {
             if (resource.isReadable()) {


### PR DESCRIPTION
Hi, in tests I'm currently doing on my upcoming Spring Boot + MariaDB4j branch with support for java -jar mifos.war, I've hit the "ERROR o.m.i.j.s.JobRegisterServiceImpl - Could not schedule job: Update Non Performing Assets java.lang.IllegalArgumentException: Code has no @CronTarget with this job name (@see JobName); seems like DB/code are not in line: Update Non Performing Assets" etc. and found out that this was because the CronMethodParser had a subtle bug preventing it from working if WAR is NOT unpacked - fixed by this.

OK to merge in?
