### PR TITLE
MIFOSX-1552 Fix which makes gradlew war produce an executable WAR, just like standard gradlew build does

### DIFF
--- a/mifosng-provider/build.gradle
+++ b/mifosng-provider/build.gradle
@@ -201,6 +201,7 @@ task deployPentahoReports() {
 
 war {
     it.dependsOn deployPentahoReports
+    war.finalizedBy(bootRepackage)
 }
 
 license {


### PR DESCRIPTION
Fixed Gradle war task by adding war.finalizedBy(bootRepackage), so that gradlew war produces an executable WAR, just like standard gradlew build does. This resolves the problem mentioned in the PS on http://blog2.vorburger.ch/2014/09/mifos-executable-war-with-mariadb4j.html

@vishwasbabu I'm submitting this as a PR instead of just merging it in myself BECAUSE this will likely increase the file size of the WAR produced by quite a bit. If you're just about to cut that release you mentioned in private email, perhaps you'd like to hold off with merging this one until after, perhaps until after I've resolved that pending Windows issue - your call (I'm fine either way).
