### PR TITLE
#MIFOSX-1566 Added min/max number of clients per group rule for activate/activating group

### DIFF
--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/client/domain/Client.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/client/domain/Client.java
@@ -298,9 +298,12 @@ public final class Client extends AbstractPersistable<Long> {
         final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
         validateNameParts(dataValidationErrors);
         validateActivationDate(dataValidationErrors);
+        validateClientsGroupRules(dataValidationErrors);
+        
         if (!dataValidationErrors.isEmpty()) { throw new PlatformApiDataValidationException(dataValidationErrors); }
+        
     }
-
+    
     public boolean isAccountNumberRequiresAutoGeneration() {
         return this.accountNumberRequiresAutoGeneration;
     }
@@ -566,6 +569,18 @@ public final class Client extends AbstractPersistable<Long> {
                         ClientApiConstants.activationDateParamName, getActivationLocalDate());
                 dataValidationErrors.add(error);
             }
+        }
+    }
+    
+    /*
+     * To become a part of a group, group may have set of criteria to be met
+     * before client can become member of it. This method is placeholder for
+     * such validation.
+     */
+
+    private void validateClientsGroupRules(final List<ApiParameterError> dataValidationErrors) {
+        for (Group group : this.groups) {
+            group.validateGroupHasMoreThanRequiredNumberOfClientsAngLogError(dataValidationErrors);
         }
     }
 

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/domain/GroupLevel.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/domain/GroupLevel.java
@@ -30,6 +30,12 @@ public class GroupLevel extends AbstractPersistable<Long> {
     @Column(name = "can_have_clients", nullable = false)
     private boolean canHaveClients = false;
 
+    @Column(name = "min_clients", nullable = false)
+    private final Long minClients;
+    
+    @Column(name = "max_clients", nullable = false)
+    private final Long maxClients;
+    
     public GroupLevel() {
 
         this.parentId = null;
@@ -37,17 +43,21 @@ public class GroupLevel extends AbstractPersistable<Long> {
         this.levelName = null;
         this.recursable = false;
         this.canHaveClients = false;
+        this.minClients = null;
+        this.maxClients = null;
 
     }
 
     public GroupLevel(final Long parentId, final boolean isSuperParent, final String levelName, final boolean recursable,
-            final boolean canHaveClients) {
+            final boolean canHaveClients, final Long minClients, final Long maxClients) {
 
         this.superParent = isSuperParent;
         this.parentId = parentId;
         this.levelName = levelName;
         this.recursable = recursable;
         this.canHaveClients = canHaveClients;
+        this.minClients = minClients;
+        this.maxClients = maxClients;
 
     }
 
@@ -77,5 +87,13 @@ public class GroupLevel extends AbstractPersistable<Long> {
 
     public boolean isCenter() {
         return this.levelName.equalsIgnoreCase("Center");
+    }
+    
+    public Long getMinClients(){
+        return this.minClients;
+    }
+    
+    public Long getMaxClients(){
+        return this.maxClients;
     }
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/service/GroupingTypesWritePlatformServiceJpaRepositoryImpl.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/group/service/GroupingTypesWritePlatformServiceJpaRepositoryImpl.java
@@ -10,13 +10,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
 import org.joda.time.LocalDate;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 import org.mifosplatform.commands.domain.CommandWrapper;
 import org.mifosplatform.commands.service.CommandProcessingService;
 import org.mifosplatform.commands.service.CommandWrapperBuilder;
@@ -229,12 +226,10 @@ public class GroupingTypesWritePlatformServiceJpaRepositoryImpl implements Group
 
             final Group group = this.groupRepository.findOneWithNotFoundDetection(groupId);
 
-            final Locale locale = command.extractLocale();
-            final DateTimeFormatter fmt = DateTimeFormat.forPattern(command.dateFormat()).withLocale(locale);
             final LocalDate activationDate = command.localDateValueOfParameterNamed("activationDate");
 
             validateOfficeOpeningDateisAfterGroupOrCenterOpeningDate(group.getOffice(), group.getGroupLevel(), activationDate);
-            group.activate(currentUser, fmt, activationDate);
+            group.activate(currentUser, activationDate);
 
             this.groupRepository.saveAndFlush(group);
 

--- a/mifosng-provider/src/main/resources/sql/migrations/core_db/V207__min_max_clients_per_group.sql
+++ b/mifosng-provider/src/main/resources/sql/migrations/core_db/V207__min_max_clients_per_group.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `m_group_level`
+	ADD COLUMN `min_clients` INT(11) NOT NULL DEFAULT '0' AFTER `can_have_clients`,
+	ADD COLUMN `max_clients` INT(11) NOT NULL DEFAULT '0' AFTER `min_clients`;


### PR DESCRIPTION
###### Features

1> Only minimum number of clients rule can be set (no limitation on maximum number of clients)
2> Only maximum number of clients rule can be set (no limitation on minimum number of clients)
3> Both minimum number of clients rule and maximum number of clients rule can be set together
4> Above rules are validate only on active groups or during activation of clients.
5> While adding new client to a group maximum number of clients rule need to satisfy
###### Known issues

 But none of the above rule is validated during closing of client(belongs to a group) or transferring of the client from one group to another group or dis-associating of client from a group
The reason is for operational convenience, example, in case of client death, one has to close the client irrespective of groups total number of clients may fall below minimum number of clients rule.
Check list
- [ ]  Integration test cases written - can't be done as m_group_level does not have any write APIs
- [x]  Pull request has a Jira issue
- [x]  JIRA number as a part of the commit message
- [x]  Code has been formatted
- [x]  Work is present in a single commit
- [x]  Rebased on top of the latest code from develop branch
- [ ]  "gradlew licenseFormatMain licenseFormatTest licenseFormatIntegrationTest" has been run, No new file is added
- [ ]  API documentation, does not have any impact on API docs
