### PR TITLE
.travis.yml config to cache Maven repo (~/.m2) - faster, and more reliab...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@ env:
 cache:
   apt: true
   directories:
+  - $HOME/.gradle
   - $HOME/.m2


### PR DESCRIPTION
...le (less bad PRs due to spurious build failures due to unreachable http://repository.pentaho.org)
