### PR TITLE
#MIFOSX-1680 Allow to modifiy frequncy and intervals if calendar is NOT synced with any active entity

### DIFF
--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/calendar/domain/Calendar.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/calendar/domain/Calendar.java
@@ -221,7 +221,7 @@ public class Calendar extends AbstractAuditableCustom<AppUser, Long> {
 
     }
 
-    public Map<String, Object> update(final JsonCommand command) {
+    public Map<String, Object> update(final JsonCommand command, final Boolean areActiveEntitiesSynced ) {
 
         final Map<String, Object> actualChanges = new LinkedHashMap<>(9);
 
@@ -328,6 +328,25 @@ public class Calendar extends AbstractAuditableCustom<AppUser, Long> {
 
         final String newRecurrence = Calendar.constructRecurrence(command, this);
         if (!StringUtils.isBlank(this.recurrence) && !newRecurrence.equalsIgnoreCase(this.recurrence)) {
+            /*
+             * If active entities like JLG loan or RD accounts are synced to the
+             * calendar then do not allow to change meeting frequency
+             */
+
+            if ( areActiveEntitiesSynced && !CalendarUtils.isFrequencySame(this.recurrence, newRecurrence)) {
+                final String defaultUserMessage = "Update of meeting frequency is not supported";
+                throw new CalendarParameterUpdateNotSupportedException("meeting.frequency", defaultUserMessage);
+            }
+
+            /*
+             * If active entities like JLG loan or RD accounts are synced to the
+             * calendar then do not allow to change meeting interval
+             */
+
+            if (areActiveEntitiesSynced && !CalendarUtils.isIntervalSame(this.recurrence, newRecurrence)) {
+                final String defaultUserMessage = "Update of meeting interval is not supported";
+                throw new CalendarParameterUpdateNotSupportedException("meeting.interval", defaultUserMessage);
+            }
 
             actualChanges.put("recurrence", newRecurrence);
             this.recurrence = StringUtils.defaultIfEmpty(newRecurrence, null);

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/calendar/serialization/CalendarCommandFromApiJsonDeserializer.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/calendar/serialization/CalendarCommandFromApiJsonDeserializer.java
@@ -319,33 +319,5 @@ public class CalendarCommandFromApiJsonDeserializer extends AbstractFromApiJsonD
         if (!dataValidationErrors.isEmpty()) { throw new PlatformApiDataValidationException("validation.msg.validation.errors.exist",
                 "Validation errors exist.", dataValidationErrors); }
     }
-
-    public void validateBusinessRulesForUpdate(final String json, final Integer numberOfActiveLoansSyncedTheCalendar) {
-
-        
-        final JsonElement element = this.fromApiJsonHelper.parse(json);
-
-        /*
-         * BR1: If calendar is not associated with any of the active loans, RD
-         * accounts and any other active entity then only frequency and interval
-         * are allowed to change
-         */
-
-        if (numberOfActiveLoansSyncedTheCalendar > 0) {
-
-            if (this.fromApiJsonHelper.parameterExists(CALENDAR_SUPPORTED_PARAMETERS.FREQUENCY.getValue(), element)) {
-                final String defaultUserMessage = "Update of meeting frequency is not supported";
-                throw new CalendarParameterUpdateNotSupportedException("meeting.frequency", defaultUserMessage);
-            }
-
-            if (this.fromApiJsonHelper.parameterExists(CALENDAR_SUPPORTED_PARAMETERS.INTERVAL.getValue(), element)) {
-                final String defaultUserMessage = "Update of meeting interval is not supported";
-                throw new CalendarParameterUpdateNotSupportedException("meeting.interval", defaultUserMessage);
-            }
-
-        }
-        
-    }
-
         
 }


### PR DESCRIPTION
   By design, calender update API takes, frequency and intervals as input even when they are not intended to modify/update these attributes, because of this, the new validation was always giving error even if one want to modify other attributes of the calendar such as day of meeting etc.

   Now the issue is fixed by adding additional to check, calendar has any active loans associated with it or not.
