### PR TITLE
Upgraded MariaDB4j dependency from v2.1.1 to v2.1.3, to fix Windows problem

### DIFF
--- a/mifosng-provider/dependencies.gradle
+++ b/mifosng-provider/dependencies.gradle
@@ -14,7 +14,7 @@ dependencies {
             )
 
     compile(
-               // [group: 'ch.vorburger.mariaDB4j', name: 'mariaDB4j', version: '2.1.1'],
+               // [group: 'ch.vorburger.mariaDB4j', name: 'mariaDB4j', version: '2.1.3'],
 
                 [group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: springBootVersion],
                 [group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: springBootVersion],

--- a/mifosng-provider/dev-dependencies.gradle
+++ b/mifosng-provider/dev-dependencies.gradle
@@ -14,7 +14,7 @@ dependencies {
             )
 
     compile(
-                [group: 'ch.vorburger.mariaDB4j', name: 'mariaDB4j', version: '2.1.1'],
+                [group: 'ch.vorburger.mariaDB4j', name: 'mariaDB4j', version: '2.1.3'],
 
                 [group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: springBootVersion],
                 [group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: springBootVersion],


### PR DESCRIPTION
@vishwasbabu this finally fixes that "mysql_install_db was not found, neither in bin/ nor in scripts/ under ..." Windows problem you know of (see https://github.com/vorburger/MariaDB4j/issues/19) for the self contained standalone java -jar *.war launcher.
