### PR TITLE
Fixed group loan date change and rechduling date issues. Bug: MIFOSX-1765

### DIFF
--- a/mifosng-provider/src/integrationTest/java/org/mifosplatform/integrationtests/DisbursalAndRepaymentScheduleTest.java
+++ b/mifosng-provider/src/integrationTest/java/org/mifosplatform/integrationtests/DisbursalAndRepaymentScheduleTest.java
@@ -1,0 +1,353 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.mifosplatform.integrationtests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mifosplatform.integrationtests.common.*;
+import org.mifosplatform.integrationtests.common.loans.*;
+
+import com.jayway.restassured.builder.RequestSpecBuilder;
+import com.jayway.restassured.builder.ResponseSpecBuilder;
+import com.jayway.restassured.http.ContentType;
+import com.jayway.restassured.specification.RequestSpecification;
+import com.jayway.restassured.specification.ResponseSpecification;
+
+/**
+ * Tests loan schedule change based on group meeting changes and loan
+ * rescheduling
+ **/
+@SuppressWarnings({ "rawtypes" })
+public class DisbursalAndRepaymentScheduleTest {
+
+    private ResponseSpecification responseSpec;
+    private ResponseSpecification responseSpecForStatusCode403;
+    private ResponseSpecification generalResponseSpec;
+    private RequestSpecification requestSpec;
+    private LoanTransactionHelper loanTransactionHelper;
+    private LoanRescheduleRequestHelper loanRescheduleRequestHelper;
+    private Integer loanRescheduleRequestId;
+    private Integer clientId;
+    private Integer groupId;
+    private Integer groupCalendarId;
+    private Integer loanProductId;
+    private Integer loanId;
+    private final String loanPrincipalAmount = "100000.00";
+    private final String numberOfRepayments = "12";
+    private final String interestRatePerPeriod = "18";
+
+    private final SimpleDateFormat dateFormatterMifosStandard = new SimpleDateFormat("dd MMMM yyyy");
+
+    @Before
+    public void setup() {
+        Utils.initializeRESTAssured();
+    }
+
+    @Test
+    public void testRescheduleJLGLoanSynk() {
+        System.out.println("---------------------------------STARTING RESCHEDULE JLG LOAN TEST ------------------------------------------");
+
+        Calendar meetingCalendar = Calendar.getInstance();
+        meetingCalendar.setFirstDayOfWeek(Calendar.MONDAY);
+        meetingCalendar.setTime(new java.util.Date());
+
+        int today = meetingCalendar.get(Calendar.DAY_OF_WEEK);
+        // making sure that the meeting calendar is set for the coming monday.
+        if (today >= Calendar.MONDAY) {
+            meetingCalendar.add(Calendar.DAY_OF_YEAR, +(Calendar.MONDAY - today + 7));
+        } else {
+            meetingCalendar.add(Calendar.DAY_OF_YEAR, +(Calendar.MONDAY - today));
+        }
+
+        Calendar groupMeetingChangeCalendar = (Calendar) meetingCalendar.clone();
+
+        meetingCalendar.add(Calendar.WEEK_OF_YEAR, -3);
+
+        final String groupMeetingDate = this.dateFormatterMifosStandard.format(meetingCalendar.getTime());
+
+        final String disbursalDate = groupMeetingDate; // first meeting date
+        // after group creation
+
+        final String rescheduleSubmittedDate = this.dateFormatterMifosStandard.format(new java.util.Date());
+
+        final String loanType = "jlg";
+        final String rescheduleInterestRate = "28.0";
+        groupMeetingChangeCalendar.add(Calendar.DAY_OF_YEAR, 1);
+        final String groupMeetingNewStartDate = this.dateFormatterMifosStandard.format(groupMeetingChangeCalendar.getTime());
+        // The date
+        // from
+        // which we
+        // start the
+        // new group
+        // meeting
+        // occasion,
+        // this is a
+        // tuesday.
+        groupMeetingChangeCalendar.add(Calendar.WEEK_OF_YEAR, 2);
+        final String rescheduleDate = this.dateFormatterMifosStandard.format(groupMeetingChangeCalendar.getTime());
+
+        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
+        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
+        this.requestSpec.header("X-Mifos-Platform-TenantId", "default");
+        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
+        this.generalResponseSpec = new ResponseSpecBuilder().build();
+        this.loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
+
+        this.loanRescheduleRequestHelper = new LoanRescheduleRequestHelper(this.requestSpec, this.responseSpec);
+        System.out.println("---------------------------------CREATING ENTITIES AND JLG LOAN ------------------------------------------");
+        // create all required entities
+        this.createRequiredEntitiesForJLGLoanSync(groupMeetingDate);
+
+        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal(loanPrincipalAmount).withLoanTermFrequency("24")
+                .withLoanTermFrequencyAsWeeks().withNumberOfRepayments("12").withRepaymentEveryAfter("2")
+                .withRepaymentFrequencyTypeAsMonths().withAmortizationTypeAsEqualInstallments().withInterestCalculationPeriodTypeAsDays()
+                .withInterestRatePerPeriod(interestRatePerPeriod).withRepaymentFrequencyTypeAsWeeks().withSubmittedOnDate(disbursalDate)
+                .withExpectedDisbursementDate(disbursalDate).withLoanType(loanType).withSyncDisbursementWithMeetin()
+                .withCalendarID(this.groupCalendarId.toString())
+                .build(this.clientId.toString(), this.groupId.toString(), this.loanProductId.toString(), null);
+
+        this.loanId = this.loanTransactionHelper.getLoanId(loanApplicationJSON);
+
+        // Test for loan account is created
+        Assert.assertNotNull(this.loanId);
+        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(this.requestSpec, this.responseSpec, this.loanId);
+
+        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+
+        // Test for loan account is created, can be approved
+        this.loanTransactionHelper.approveLoan(disbursalDate, this.loanId);
+        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(this.requestSpec, this.responseSpec, this.loanId);
+        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
+
+        // Test for loan account approved can be disbursed
+        this.loanTransactionHelper.disburseLoan(disbursalDate, this.loanId);
+        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(this.requestSpec, this.responseSpec, this.loanId);
+        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+
+        System.out.println("---------------------------------CHANGING GROUP MEETING DATE ------------------------------------------");
+        CalendarHelper.updateMeetingCalendarForGroup(this.requestSpec, this.responseSpec, this.groupId, this.groupCalendarId.toString(),
+                groupMeetingNewStartDate, "2", "2", "2"); // New meeting dates
+                                                          // will be the tuesday
+                                                          // after the
+        // coming
+        // monday
+
+        ArrayList loanRepaymnetSchedule = this.loanTransactionHelper
+                .getLoanRepaymentSchedule(requestSpec, generalResponseSpec, this.loanId);
+
+        ArrayList dueDateLoanSchedule = (ArrayList) ((HashMap) loanRepaymnetSchedule.get(2)).get("dueDate");
+        Calendar dueDateCalendar = Calendar.getInstance();
+        dueDateCalendar.setFirstDayOfWeek(Calendar.MONDAY);
+        dueDateCalendar.set((Integer) dueDateLoanSchedule.get(0), (Integer) dueDateLoanSchedule.get(1) - 1,
+                (Integer) dueDateLoanSchedule.get(2));
+        assertEquals("AFTER MEETING CHANGE DATE THE NEXT REPAYMENT SHOULD BE ON TUESDAY", 3, dueDateCalendar.get(Calendar.DAY_OF_WEEK));
+
+        System.out.println("---------------------------------CREATING LOAN RESCHEDULE REQUEST------------------------------------------");
+
+        String requestJSON = new LoanRescheduleRequestTestBuilder().updateGraceOnInterest("2").updateGraceOnPrincipal("2")
+                .updateNewInterestRate(rescheduleInterestRate).updateRescheduleFromDate(rescheduleDate)
+                .updateSubmittedOnDate(rescheduleSubmittedDate).build(this.loanId.toString());
+
+        this.loanRescheduleRequestId = this.loanRescheduleRequestHelper.createLoanRescheduleRequest(requestJSON);
+        this.loanRescheduleRequestHelper.verifyCreationOfLoanRescheduleRequest(this.loanRescheduleRequestId);
+
+        loanRepaymnetSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(requestSpec, generalResponseSpec, this.loanId);
+        dueDateLoanSchedule = (ArrayList) ((HashMap) loanRepaymnetSchedule.get(2)).get("dueDate");
+        dueDateCalendar.set((Integer) dueDateLoanSchedule.get(0), (Integer) dueDateLoanSchedule.get(1) - 1,
+                (Integer) dueDateLoanSchedule.get(2));
+        assertEquals("AFTER MEETING CHANGE DATE THE NEXT REPAYMENT SHOULD BE ON TUESDAY, EVEN AFTER LOAN RESCHEDULE REQUEST WAS SENT", 3,
+                dueDateCalendar.get(Calendar.DAY_OF_WEEK));
+
+        System.out.println("Successfully created loan reschedule request (ID: " + this.loanRescheduleRequestId + ")");
+
+        System.out.println("-----------------------------APPROVING LOAN RESCHEDULE REQUEST--------------------------");
+
+        requestJSON = new LoanRescheduleRequestTestBuilder().updateSubmittedOnDate(rescheduleSubmittedDate)
+                .getApproveLoanRescheduleRequestJSON();
+        this.loanRescheduleRequestHelper.approveLoanRescheduleRequest(this.loanRescheduleRequestId, requestJSON);
+
+        final HashMap response = (HashMap) this.loanRescheduleRequestHelper.getLoanRescheduleRequest(loanRescheduleRequestId, "statusEnum");
+        assertTrue((Boolean) response.get("approved"));
+
+        loanRepaymnetSchedule = this.loanTransactionHelper.getLoanRepaymentSchedule(requestSpec, generalResponseSpec, this.loanId);
+
+        dueDateLoanSchedule = (ArrayList) ((HashMap) loanRepaymnetSchedule.get(2)).get("dueDate");
+        dueDateCalendar.set((Integer) dueDateLoanSchedule.get(0), (Integer) dueDateLoanSchedule.get(1) - 1,
+                (Integer) dueDateLoanSchedule.get(2));
+        assertEquals("AFTER MEETING CHANGE DATE THE NEXT REPAYMENT SHOULD BE ON TUESDAY, EVEN AFTER RESCHEDULE", 3,
+                dueDateCalendar.get(Calendar.DAY_OF_WEEK));
+        System.out.println("Successfully changed group meeting date (CAELNDAR ID: " + this.groupCalendarId
+                + ") and rescheduled loan (RESCHEDULE ID: " + this.loanRescheduleRequestId + ")");
+
+        this.loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpecForStatusCode403);
+    }
+
+    @Test
+    public void testChangeGroupMeetingMaturedOnDate() {
+        System.out
+                .println("---------------------------------STARTING GROUP LOAN MEETING CHANGE DATE EXPECTED MATURED CHANGE------------------------------------------");
+
+        Calendar meetingCalendar = Calendar.getInstance();
+        meetingCalendar.setFirstDayOfWeek(Calendar.MONDAY);
+        meetingCalendar.setTime(new java.util.Date());
+
+        int today = meetingCalendar.get(Calendar.DAY_OF_WEEK);
+        // making sure that the meeting calendar is set for the coming monday.
+        if (today >= Calendar.MONDAY) {
+            meetingCalendar.add(Calendar.DAY_OF_YEAR, +(Calendar.MONDAY - today + 7));
+        } else {
+            meetingCalendar.add(Calendar.DAY_OF_YEAR, +(Calendar.MONDAY - today));
+        }
+
+        Calendar groupMeetingChangeCalendar = (Calendar) meetingCalendar.clone();
+
+        meetingCalendar.add(Calendar.WEEK_OF_YEAR, -3);
+
+        final String groupMeetingDate = this.dateFormatterMifosStandard.format(meetingCalendar.getTime());
+
+        final String disbursalDate = groupMeetingDate; // first meeting date
+                                                       // after group creation
+
+        final String loanType = "jlg";
+        groupMeetingChangeCalendar.add(Calendar.DAY_OF_YEAR, 1);
+        final String groupMeetingNewStartDate = this.dateFormatterMifosStandard.format(groupMeetingChangeCalendar.getTime());
+        // The date
+        // from
+        // which we
+        // start the
+        // new group
+        // meeting
+        // occasion,
+        // this is a
+        // tuesday.
+
+        this.requestSpec = new RequestSpecBuilder().setContentType(ContentType.JSON).build();
+        this.requestSpec.header("Authorization", "Basic " + Utils.loginIntoServerAndGetBase64EncodedAuthenticationKey());
+        this.requestSpec.header("X-Mifos-Platform-TenantId", "default");
+        this.responseSpec = new ResponseSpecBuilder().expectStatusCode(200).build();
+        this.generalResponseSpec = new ResponseSpecBuilder().build();
+        this.loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpec);
+
+        this.loanRescheduleRequestHelper = new LoanRescheduleRequestHelper(this.requestSpec, this.responseSpec);
+        System.out.println("---------------------------------CREATING ENTITIES AND JLG LOAN ------------------------------------------");
+        // create all required entities
+        this.createRequiredEntitiesForJLGLoanSync(groupMeetingDate);
+
+        final String loanApplicationJSON = new LoanApplicationTestBuilder().withPrincipal(loanPrincipalAmount).withLoanTermFrequency("24")
+                .withLoanTermFrequencyAsWeeks().withNumberOfRepayments("12").withRepaymentEveryAfter("2")
+                .withRepaymentFrequencyTypeAsMonths().withAmortizationTypeAsEqualInstallments().withInterestCalculationPeriodTypeAsDays()
+                .withInterestRatePerPeriod(interestRatePerPeriod).withRepaymentFrequencyTypeAsWeeks().withSubmittedOnDate(disbursalDate)
+                .withExpectedDisbursementDate(disbursalDate).withLoanType(loanType).withSyncDisbursementWithMeetin()
+                .withCalendarID(this.groupCalendarId.toString())
+                .build(this.clientId.toString(), this.groupId.toString(), this.loanProductId.toString(), null);
+
+        this.loanId = this.loanTransactionHelper.getLoanId(loanApplicationJSON);
+
+        // Test for loan account is created
+        Assert.assertNotNull(this.loanId);
+        HashMap loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(this.requestSpec, this.responseSpec, this.loanId);
+
+        LoanStatusChecker.verifyLoanIsPending(loanStatusHashMap);
+
+        // Test for loan account is created, can be approved
+        this.loanTransactionHelper.approveLoan(disbursalDate, this.loanId);
+        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(this.requestSpec, this.responseSpec, this.loanId);
+        LoanStatusChecker.verifyLoanIsApproved(loanStatusHashMap);
+
+        // Test for loan account approved can be disbursed
+        this.loanTransactionHelper.disburseLoan(disbursalDate, this.loanId);
+        loanStatusHashMap = LoanStatusChecker.getStatusOfLoan(this.requestSpec, this.responseSpec, this.loanId);
+        LoanStatusChecker.verifyLoanIsActive(loanStatusHashMap);
+
+        System.out.println("---------------------------------CHANGING GROUP MEETING DATE ------------------------------------------");
+        CalendarHelper.updateMeetingCalendarForGroup(this.requestSpec, this.responseSpec, this.groupId, this.groupCalendarId.toString(),
+                groupMeetingNewStartDate, "2", "2", "2"); // New meeting dates
+                                                          // will be the tuesday
+                                                          // after the
+                                                          // coming
+                                                          // monday
+
+        Calendar expectedMaturityCalendar = Calendar.getInstance();
+        expectedMaturityCalendar.setFirstDayOfWeek(Calendar.MONDAY);
+        ArrayList expectedMaturityDate = ((ArrayList) ((HashMap) this.loanTransactionHelper.getLoanDetail(requestSpec, generalResponseSpec,
+                this.loanId, "timeline")).get("expectedMaturityDate"));
+
+        expectedMaturityCalendar.set((Integer) expectedMaturityDate.get(0), (Integer) expectedMaturityDate.get(1) - 1,
+                (Integer) expectedMaturityDate.get(2));
+
+        assertEquals("AFTER MEETING CHANGE DATE THE EXPECTED MATURITY SHOULD BE ON TUESDAY", 3,
+                expectedMaturityCalendar.get(Calendar.DAY_OF_WEEK));
+
+        this.loanTransactionHelper = new LoanTransactionHelper(this.requestSpec, this.responseSpecForStatusCode403);
+    }
+
+    /**
+     * entities for jlg loan
+     **/
+    private void createRequiredEntitiesForJLGLoanSync(final String groupActivationDate) {
+        this.createGroupEntityWithCalendar("2", "2", "1", groupActivationDate);// frequency=2:Weekly
+        // , interval=2:
+        // Every two weeks ,
+        // repeatsOnDay=1:Monday
+        // groupActivationDate is decided by the current date
+        this.createClientEntity();
+        this.associateClientToGroup(this.groupId, this.clientId);
+        this.createLoanProductEntity();
+
+    }
+
+    /*
+     * Associate client to the group
+     */
+
+    private void associateClientToGroup(final Integer groupId, final Integer clientId) {
+        GroupHelper.associateClient(this.requestSpec, this.responseSpec, groupId.toString(), clientId.toString());
+        GroupHelper.verifyGroupMembers(this.requestSpec, this.responseSpec, groupId, clientId);
+    }
+
+    private void createGroupEntityWithCalendar(final String frequency, final String interval, final String repeatsOnDay,
+            final String groupActivationDate) {
+        this.groupId = GroupHelper.createGroup(this.requestSpec, this.responseSpec, groupActivationDate);
+        GroupHelper.verifyGroupCreatedOnServer(this.requestSpec, this.responseSpec, this.groupId);
+
+        final String startDate = groupActivationDate;
+
+        this.setGroupCalendarId(CalendarHelper.createMeetingCalendarForGroup(this.requestSpec, this.responseSpec, this.groupId, startDate,
+                frequency, interval, repeatsOnDay));
+    }
+
+    /**
+     * create a new client
+     **/
+    private void createClientEntity() {
+        this.clientId = ClientHelper.createClient(this.requestSpec, this.responseSpec);
+        ClientHelper.verifyClientCreatedOnServer(this.requestSpec, this.responseSpec, this.clientId);
+    }
+
+    /**
+     * create a new loan product
+     **/
+    private void createLoanProductEntity() {
+        final String loanProductJSON = new LoanProductTestBuilder().withPrincipal(loanPrincipalAmount)
+                .withNumberOfRepayments(numberOfRepayments).withinterestRatePerPeriod(interestRatePerPeriod)
+                .withInterestRateFrequencyTypeAsYear().build(null);
+        this.loanProductId = this.loanTransactionHelper.getLoanProductId(loanProductJSON);
+    }
+
+    public void setGroupCalendarId(Integer groupCalendarId) {
+        this.groupCalendarId = groupCalendarId;
+    }
+}

--- a/mifosng-provider/src/integrationTest/java/org/mifosplatform/integrationtests/common/CalendarHelper.java
+++ b/mifosng-provider/src/integrationTest/java/org/mifosplatform/integrationtests/common/CalendarHelper.java
@@ -20,29 +20,43 @@ public class CalendarHelper {
     private static final String PARENT_ENTITY_NAME = "groups/";
     private static final String ENITY_NAME = "/calendars";
 
-    public static Integer createMeetingCalendarForGroup(final RequestSpecification requestSpec, final ResponseSpecification responseSpec, 
-    		final Integer groupId, final String startDate, final String frequency, final String interval, final String repeatsOnDay) {
-    	
+    public static Integer createMeetingCalendarForGroup(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
+            final Integer groupId, final String startDate, final String frequency, final String interval, final String repeatsOnDay) {
+
         System.out.println("---------------------------------CREATING A MEETING CALENDAR FOR THE GROUP------------------------------");
-        
-        final String CALENDAR_RESOURCE_URL = BASE_URL + PARENT_ENTITY_NAME + groupId + ENITY_NAME + "?"  + Utils.TENANT_IDENTIFIER;
-        
+
+        final String CALENDAR_RESOURCE_URL = BASE_URL + PARENT_ENTITY_NAME + groupId + ENITY_NAME + "?" + Utils.TENANT_IDENTIFIER;
+
         System.out.println(CALENDAR_RESOURCE_URL);
-        
-        return Utils.performServerPost(requestSpec, responseSpec, CALENDAR_RESOURCE_URL, getTestCalendarAsJSON(frequency, interval, repeatsOnDay, startDate),
-                "resourceId");
+
+        return Utils.performServerPost(requestSpec, responseSpec, CALENDAR_RESOURCE_URL,
+                getTestCalendarAsJSON(frequency, interval, repeatsOnDay, startDate), "resourceId");
     }
 
-    public static String getTestCalendarAsJSON(final String frequency, final String interval,final String repeatsOnDay,
-    		final String startDate) {
-    	
+    public static Integer updateMeetingCalendarForGroup(final RequestSpecification requestSpec, final ResponseSpecification responseSpec,
+            final Integer groupId, String calendarID, final String startDate, final String frequency, final String interval,
+            final String repeatsOnDay) {
+
+        System.out.println("---------------------------------UPDATING A MEETING CALENDAR FOR THE GROUP------------------------------");
+
+        final String CALENDAR_RESOURCE_URL = BASE_URL + PARENT_ENTITY_NAME + groupId + ENITY_NAME + "/" + calendarID;
+
+        System.out.println(CALENDAR_RESOURCE_URL);
+        // TODO: check that resource id indeed exists in calendar update put.
+        return Utils.performServerPut(requestSpec, responseSpec, CALENDAR_RESOURCE_URL,
+                getTestCalendarAsJSON(frequency, interval, repeatsOnDay, startDate), "resourceId");
+    }
+
+    public static String getTestCalendarAsJSON(final String frequency, final String interval, final String repeatsOnDay,
+            final String startDate) {
+
         final HashMap<String, String> map = new HashMap<>();
         map.put("dateFormat", "dd MMMM yyyy");
         map.put("locale", "en");
         map.put("frequency", frequency);
         map.put("interval", interval);
         map.put("repeating", "true");
-        map.put("repeatsOnDay", repeatsOnDay );
+        map.put("repeatsOnDay", repeatsOnDay);
         map.put("title", Utils.randomNameGenerator("groups_CollectionMeeting", 4));
         map.put("typeId", "1");
         map.put("startDate", startDate);
@@ -54,7 +68,8 @@ public class CalendarHelper {
             final Integer generatedGroupId, final Integer generatedCalendarId) {
         System.out.println("------------------------------CHECK CALENDAR DETAILS------------------------------------\n");
         final String CLIENT_URL = "/mifosng-provider/api/v1/groups/" + generatedGroupId + "?associations=all&" + Utils.TENANT_IDENTIFIER;
-        final String responseCalendarDetailsinJSON = Utils.performServerGet(requestSpec, responseSpec, CLIENT_URL, "collectionMeetingCalendar");
+        final String responseCalendarDetailsinJSON = Utils.performServerGet(requestSpec, responseSpec, CLIENT_URL,
+                "collectionMeetingCalendar");
         final Integer responseCalendarId = from(responseCalendarDetailsinJSON).get("id");
         assertEquals("ERROR IN CREATING THE CALENDAR", generatedCalendarId, responseCalendarId);
     }

--- a/mifosng-provider/src/integrationTest/java/org/mifosplatform/integrationtests/common/loans/LoanApplicationTestBuilder.java
+++ b/mifosng-provider/src/integrationTest/java/org/mifosplatform/integrationtests/common/loans/LoanApplicationTestBuilder.java
@@ -50,16 +50,37 @@ public class LoanApplicationTestBuilder {
     private String recalculationCompoundingFrequencyDate = null;
     private String repaymentsStartingFromDate = null;
 
+    private String calendarId;
+    private boolean syncDisbursementWithMeeting = false;
+
+    public String build(final String clientID, final String groupID, final String loanProductId, final String savingsID) {
+        final HashMap<String, Object> map = new HashMap<>();
+        map.put("groupId", groupID);
+        map.put("clientId", clientID);
+        if (this.loanType == "jlg") {
+            if (this.calendarId != null) {
+                map.put("calendarId", this.calendarId);
+            }
+            map.put("syncDisbursementWithMeeting", this.syncDisbursementWithMeeting);
+        }
+        return build(map, loanProductId, savingsID);
+    }
+
     public String build(final String ID, final String loanProductId, final String savingsID) {
 
         final HashMap<String, Object> map = new HashMap<>();
-        map.put("dateFormat", "dd MMMM yyyy");
-        map.put("locale", "en_GB");
+
         if (this.loanType == "group") {
             map.put("groupId", ID);
         } else {
             map.put("clientId", ID);
         }
+        return build(map, loanProductId, savingsID);
+    }
+
+    private String build(final HashMap<String, Object> map, final String loanProductId, final String savingsID) {
+        map.put("dateFormat", "dd MMMM yyyy");
+        map.put("locale", "en_GB");
         map.put("productId", loanProductId);
         map.put("principal", this.principal);
         map.put("loanTermFrequency", this.loanTermFrequency);
@@ -105,6 +126,7 @@ public class LoanApplicationTestBuilder {
         if (recalculationCompoundingFrequencyDate != null) {
             map.put("recalculationCompoundingFrequencyDate", recalculationCompoundingFrequencyDate);
         }
+
         System.out.println("Loan Application request : " + map);
         return new Gson().toJson(map);
     }
@@ -258,4 +280,32 @@ public class LoanApplicationTestBuilder {
         this.repaymentsStartingFromDate = firstRepaymentDate;
         return this;
     }
+
+    /**
+     * calendarID parameter is used to sync repayments with group meetings,
+     * especially when using jlg loans
+     *
+     * @param calendarId
+     *            the id of the calender record of the group meeting from
+     *            m_calendar table
+     * @return
+     */
+    public LoanApplicationTestBuilder withCalendarID(String calendarId) {
+        this.calendarId = calendarId;
+        return this;
+    }
+
+    /**
+     * This indicator is used mainly for jlg loans when we want to sync
+     * disbursement with the group meetings (it seems that if we do use this
+     * parameter we should also use calendarID to sync repayment with group
+     * meetings)
+     * 
+     * @return
+     */
+    public LoanApplicationTestBuilder withSyncDisbursementWithMeetin() {
+        this.syncDisbursementWithMeeting = true;
+        return this;
+    }
+
 }

--- a/mifosng-provider/src/integrationTest/java/org/mifosplatform/integrationtests/common/loans/LoanRescheduleRequestTestBuilder.java
+++ b/mifosng-provider/src/integrationTest/java/org/mifosplatform/integrationtests/common/loans/LoanRescheduleRequestTestBuilder.java
@@ -11,126 +11,133 @@ import java.util.HashMap;
 import com.google.gson.Gson;
 
 public class LoanRescheduleRequestTestBuilder {
-	private String rescheduleFromDate = "04 December 2014";
-	private String graceOnPrincipal = "2";
-	private String graceOnInterest = "2";
-	private String extraTerms = "2";
-	private Boolean recalculateInterest = false;
-	private String newInterestRate = null;
-	private String adjustedDueDate = null;
-	private String rescheduleReasonId = "1";
-	private String rescheduleReasonComment = null;
-	private String submittedOnDate = "04 September 2014";
-	
-	public String build(final String loanId) {
-		final HashMap<String, Object> map = new HashMap<>();
-		
-		map.put("dateFormat", "dd MMMM yyyy");
+
+    private String rescheduleFromDate = "04 December 2014";
+    private String graceOnPrincipal = "2";
+    private String graceOnInterest = "2";
+    private String extraTerms = "2";
+    private Boolean recalculateInterest = false;
+    private String newInterestRate = null;
+    private String adjustedDueDate = null;
+    private String rescheduleReasonId = "1";
+    private String rescheduleReasonComment = null;
+    private String submittedOnDate = "04 September 2014";
+
+    public String build(final String loanId) {
+        final HashMap<String, Object> map = new HashMap<>();
+
+        map.put("dateFormat", "dd MMMM yyyy");
         map.put("locale", "en_GB");
         map.put("loanId", loanId);
         map.put("submittedOnDate", submittedOnDate);
-		map.put("rescheduleFromDate", rescheduleFromDate);
-		
-		if(graceOnPrincipal != null) {
-			map.put("graceOnPrincipal", graceOnPrincipal);
-		}
-		
-		if(graceOnInterest != null) {
-			map.put("graceOnInterest", graceOnInterest);
-		}
-		
-		if(extraTerms != null) {
-			map.put("extraTerms", extraTerms);
-		}
-		
-		map.put("recalculateInterest", recalculateInterest);
-		
-		if(newInterestRate != null) {
-			map.put("newInterestRate", newInterestRate);
-		}
-		
-		if(adjustedDueDate != null) {
-			map.put("adjustedDueDate", adjustedDueDate);
-		}
-		
-		map.put("rescheduleReasonId", rescheduleReasonId);
-		
-		if(rescheduleReasonComment != null) {
-			map.put("rescheduleReasonComment", rescheduleReasonComment);
-		}
-		
-		return new Gson().toJson(map);
-	}
-	
-	public LoanRescheduleRequestTestBuilder updateRescheduleFromDate(final String rescheduleFromDate) {
-		if(rescheduleFromDate != null) {
-			this.rescheduleFromDate = rescheduleFromDate;
-		}
-		
-		return this;
-	}
-	
-	public LoanRescheduleRequestTestBuilder updateGraceOnPrincipal(final String graceOnPrincipal) {
-		this.graceOnPrincipal = graceOnPrincipal;
-		
-		return this;
-	}
-	
-	public LoanRescheduleRequestTestBuilder updateGraceOnInterest(final String graceOnInterest) {
-		this.graceOnInterest = graceOnInterest;
-		
-		return this;
-	}
-	
-	public LoanRescheduleRequestTestBuilder updateExtraTerms(final String extraTerms) {
-		this.extraTerms = extraTerms;
-		
-		return this;
-	}
-	
-	public LoanRescheduleRequestTestBuilder updateRecalculateInterest(final Boolean recalculateInterest) {
-		this.recalculateInterest = recalculateInterest;
-		
-		return this;
-	}
-	
-	public LoanRescheduleRequestTestBuilder updateNewInterestRate(final String newInterestRate) {
-		this.newInterestRate = newInterestRate;
-		
-		return this;
-	}
-	
-	public LoanRescheduleRequestTestBuilder updateAdjustedDueDate(final String adjustedDueDate) {
-		this.adjustedDueDate = adjustedDueDate;
-		
-		return this;
-	}
-	
-	public LoanRescheduleRequestTestBuilder updateRescheduleReasonId(final String rescheduleReasonId) {
-		this.rescheduleReasonId = rescheduleReasonId;
-		
-		return this;
-	}
-	
-	public LoanRescheduleRequestTestBuilder updateRescheduleReasonComment(final String rescheduleReasonComment) {
-		this.rescheduleReasonComment = rescheduleReasonComment;
-		
-		return this;
-	}
-	
-	public String getRejectLoanRescheduleRequestJSON() {
-		final HashMap<String, String> map = new HashMap<>();
+        map.put("rescheduleFromDate", rescheduleFromDate);
+
+        if (graceOnPrincipal != null) {
+            map.put("graceOnPrincipal", graceOnPrincipal);
+        }
+
+        if (graceOnInterest != null) {
+            map.put("graceOnInterest", graceOnInterest);
+        }
+
+        if (extraTerms != null) {
+            map.put("extraTerms", extraTerms);
+        }
+
+        map.put("recalculateInterest", recalculateInterest);
+
+        if (newInterestRate != null) {
+            map.put("newInterestRate", newInterestRate);
+        }
+
+        if (adjustedDueDate != null) {
+            map.put("adjustedDueDate", adjustedDueDate);
+        }
+
+        map.put("rescheduleReasonId", rescheduleReasonId);
+
+        if (rescheduleReasonComment != null) {
+            map.put("rescheduleReasonComment", rescheduleReasonComment);
+        }
+
+        return new Gson().toJson(map);
+    }
+
+    public LoanRescheduleRequestTestBuilder updateRescheduleFromDate(final String rescheduleFromDate) {
+        if (rescheduleFromDate != null) {
+            this.rescheduleFromDate = rescheduleFromDate;
+        }
+
+        return this;
+    }
+
+    public LoanRescheduleRequestTestBuilder updateGraceOnPrincipal(final String graceOnPrincipal) {
+        this.graceOnPrincipal = graceOnPrincipal;
+
+        return this;
+    }
+
+    public LoanRescheduleRequestTestBuilder updateGraceOnInterest(final String graceOnInterest) {
+        this.graceOnInterest = graceOnInterest;
+
+        return this;
+    }
+
+    public LoanRescheduleRequestTestBuilder updateExtraTerms(final String extraTerms) {
+        this.extraTerms = extraTerms;
+
+        return this;
+    }
+
+    public LoanRescheduleRequestTestBuilder updateRecalculateInterest(final Boolean recalculateInterest) {
+        this.recalculateInterest = recalculateInterest;
+
+        return this;
+    }
+
+    public LoanRescheduleRequestTestBuilder updateNewInterestRate(final String newInterestRate) {
+        this.newInterestRate = newInterestRate;
+
+        return this;
+    }
+
+    public LoanRescheduleRequestTestBuilder updateAdjustedDueDate(final String adjustedDueDate) {
+        this.adjustedDueDate = adjustedDueDate;
+
+        return this;
+    }
+
+    public LoanRescheduleRequestTestBuilder updateRescheduleReasonId(final String rescheduleReasonId) {
+        this.rescheduleReasonId = rescheduleReasonId;
+
+        return this;
+    }
+
+    public LoanRescheduleRequestTestBuilder updateRescheduleReasonComment(final String rescheduleReasonComment) {
+        this.rescheduleReasonComment = rescheduleReasonComment;
+
+        return this;
+    }
+
+    public LoanRescheduleRequestTestBuilder updateSubmittedOnDate(final String submittedOnDate) {
+        this.submittedOnDate = submittedOnDate;
+
+        return this;
+    }
+
+    public String getRejectLoanRescheduleRequestJSON() {
+        final HashMap<String, String> map = new HashMap<>();
         map.put("locale", "en");
         map.put("dateFormat", "dd MMMM yyyy");
         map.put("rejectedOnDate", submittedOnDate);
         return new Gson().toJson(map);
-	}
-	
-	public String getApproveLoanRescheduleRequestJSON() {
-		final HashMap<String, String> map = new HashMap<>();
+    }
+
+    public String getApproveLoanRescheduleRequestJSON() {
+        final HashMap<String, String> map = new HashMap<>();
         map.put("locale", "en");
         map.put("dateFormat", "dd MMMM yyyy");
         map.put("approvedOnDate", submittedOnDate);
         return new Gson().toJson(map);
-	}
+    }
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/loanschedule/domain/DefaultScheduledDateGenerator.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/loanschedule/domain/DefaultScheduledDateGenerator.java
@@ -13,9 +13,15 @@ import org.joda.time.Years;
 import org.mifosplatform.organisation.holiday.service.HolidayUtil;
 import org.mifosplatform.organisation.workingdays.domain.RepaymentRescheduleType;
 import org.mifosplatform.organisation.workingdays.service.WorkingDaysUtil;
+import org.mifosplatform.portfolio.calendar.domain.Calendar;
+import org.mifosplatform.portfolio.calendar.domain.CalendarHistory;
+import org.mifosplatform.portfolio.calendar.domain.CalendarInstance;
+import org.mifosplatform.portfolio.calendar.service.CalendarUtils;
 import org.mifosplatform.portfolio.common.domain.DayOfWeekType;
 import org.mifosplatform.portfolio.common.domain.PeriodFrequencyType;
 import org.mifosplatform.portfolio.loanaccount.data.HolidayDetailDTO;
+
+import java.util.Set;
 
 public class DefaultScheduledDateGenerator implements ScheduledDateGenerator {
 
@@ -27,7 +33,7 @@ public class DefaultScheduledDateGenerator implements ScheduledDateGenerator {
         LocalDate lastRepaymentDate = loanApplicationTerms.getExpectedDisbursementDate();
         boolean isFirstRepayment = true;
         for (int repaymentPeriod = 1; repaymentPeriod <= numberOfRepayments; repaymentPeriod++) {
-            lastRepaymentDate = generateNextRepaymentDate(lastRepaymentDate, loanApplicationTerms, isFirstRepayment);
+            lastRepaymentDate = generateNextRepaymentDate(lastRepaymentDate, loanApplicationTerms, isFirstRepayment, holidayDetailDTO);
             isFirstRepayment = false;
         }
         lastRepaymentDate = adjustRepaymentDate(lastRepaymentDate, loanApplicationTerms, holidayDetailDTO);
@@ -36,15 +42,29 @@ public class DefaultScheduledDateGenerator implements ScheduledDateGenerator {
 
     @Override
     public LocalDate generateNextRepaymentDate(final LocalDate lastRepaymentDate, final LoanApplicationTerms loanApplicationTerms,
-            boolean isFirstRepayment) {
+            boolean isFirstRepayment, final HolidayDetailDTO holidayDetailDTO) {
         final LocalDate firstRepaymentPeriodDate = loanApplicationTerms.getCalculatedRepaymentsStartingFromLocalDate();
         LocalDate dueRepaymentPeriodDate = null;
         if (isFirstRepayment && firstRepaymentPeriodDate != null) {
             dueRepaymentPeriodDate = firstRepaymentPeriodDate;
         } else {
+            Calendar currentCalendar = loanApplicationTerms.getLoanCalendar();
+
             dueRepaymentPeriodDate = getRepaymentPeriodDate(loanApplicationTerms.getRepaymentPeriodFrequencyType(),
                     loanApplicationTerms.getRepaymentEvery(), lastRepaymentDate, loanApplicationTerms.getNthDay(),
                     loanApplicationTerms.getWeekDayType());
+            if (currentCalendar != null) {
+                // If we have currentCalendar object, this neans there is a
+                // calendar associated with
+                // the loan, and we should use it in order to calculate next
+                // repayment
+                LocalDate seedDate = currentCalendar.getStartDateLocalDate();
+                String reccuringString = currentCalendar.getRecurrence();
+                dueRepaymentPeriodDate = CalendarUtils.getNewRepaymentMeetingDate(reccuringString, seedDate, dueRepaymentPeriodDate,
+                        loanApplicationTerms.getRepaymentEvery(),
+                        CalendarUtils.getMeetingFrequencyFromPeriodFrequencyType(loanApplicationTerms.getLoanTermPeriodFrequencyType()),
+                        holidayDetailDTO.getWorkingDays());
+            }
         }
         return dueRepaymentPeriodDate;
     }
@@ -54,19 +74,20 @@ public class DefaultScheduledDateGenerator implements ScheduledDateGenerator {
             final HolidayDetailDTO holidayDetailDTO) {
 
         LocalDate adjustedDate = dueRepaymentPeriodDate;
-        
+
         LocalDate nextDueRepaymentPeriodDate = getRepaymentPeriodDate(loanApplicationTerms.getRepaymentPeriodFrequencyType(),
                 loanApplicationTerms.getRepaymentEvery(), adjustedDate, loanApplicationTerms.getNthDay(),
                 loanApplicationTerms.getWeekDayType());
-        
-        final RepaymentRescheduleType rescheduleType = RepaymentRescheduleType.fromInt(holidayDetailDTO.getWorkingDays().getRepaymentReschedulingType());
+
+        final RepaymentRescheduleType rescheduleType = RepaymentRescheduleType.fromInt(holidayDetailDTO.getWorkingDays()
+                .getRepaymentReschedulingType());
 
         /**
          * Fix for https://mifosforge.jira.com/browse/MIFOSX-1357
          */
         // recursively check for the next working meeting day.
-        while (WorkingDaysUtil.isNonWorkingDay(holidayDetailDTO.getWorkingDays(), nextDueRepaymentPeriodDate) &&
-                rescheduleType == RepaymentRescheduleType.MOVE_TO_NEXT_REPAYMENT_MEETING_DAY) {
+        while (WorkingDaysUtil.isNonWorkingDay(holidayDetailDTO.getWorkingDays(), nextDueRepaymentPeriodDate)
+                && rescheduleType == RepaymentRescheduleType.MOVE_TO_NEXT_REPAYMENT_MEETING_DAY) {
 
             nextDueRepaymentPeriodDate = getRepaymentPeriodDate(loanApplicationTerms.getRepaymentPeriodFrequencyType(),
                     loanApplicationTerms.getRepaymentEvery(), nextDueRepaymentPeriodDate, loanApplicationTerms.getNthDay(),
@@ -196,7 +217,7 @@ public class DefaultScheduledDateGenerator implements ScheduledDateGenerator {
         LocalDate generatedDate = loanApplicationTerms.getExpectedDisbursementDate();
         boolean isFirstRepayment = true;
         while (!generatedDate.isAfter(lastRepaymentDate)) {
-            generatedDate = generateNextRepaymentDate(generatedDate, loanApplicationTerms, isFirstRepayment);
+            generatedDate = generateNextRepaymentDate(generatedDate, loanApplicationTerms, isFirstRepayment, holidayDetailDTO);
             isFirstRepayment = false;
         }
         generatedDate = adjustRepaymentDate(generatedDate, loanApplicationTerms, holidayDetailDTO);

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/loanschedule/domain/LoanApplicationTerms.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/loanschedule/domain/LoanApplicationTerms.java
@@ -18,6 +18,7 @@ import org.joda.time.PeriodType;
 import org.mifosplatform.organisation.monetary.domain.ApplicationCurrency;
 import org.mifosplatform.organisation.monetary.domain.MonetaryCurrency;
 import org.mifosplatform.organisation.monetary.domain.Money;
+import org.mifosplatform.portfolio.calendar.domain.Calendar;
 import org.mifosplatform.portfolio.calendar.domain.CalendarInstance;
 import org.mifosplatform.portfolio.common.domain.DayOfWeekType;
 import org.mifosplatform.portfolio.common.domain.DaysInMonthType;
@@ -39,6 +40,8 @@ import org.mifosplatform.portfolio.loanproduct.domain.RecalculationFrequencyType
 public final class LoanApplicationTerms {
 
     private final ApplicationCurrency currency;
+
+    private final Calendar loanCalendar;
     private Integer loanTermFrequency;
     private final PeriodFrequencyType loanTermPeriodFrequencyType;
     private Integer numberOfRepayments;
@@ -160,7 +163,7 @@ public final class LoanApplicationTerms {
             final RecalculationFrequencyType recalculationFrequencyType, final CalendarInstance restCalendarInstance,
             final CalendarInstance compoundingCalendarInstance, final RecalculationFrequencyType compoundingFrequencyType,
             final BigDecimal principalThresholdForLastInstalment, final Integer installmentAmountInMultiplesOf,
-            final LoanPreClosureInterestCalculationStrategy preClosureInterestCalculationStrategy) {
+            final LoanPreClosureInterestCalculationStrategy preClosureInterestCalculationStrategy, final Calendar loanCalendar) {
 
         final LoanRescheduleStrategyMethod rescheduleStrategyMethod = null;
         final InterestRecalculationCompoundingMethod interestRecalculationCompoundingMethod = null;
@@ -172,7 +175,7 @@ public final class LoanApplicationTerms {
                 disbursementDatas, maxOutstandingBalance, emiAmountVariations, graceOnArrearsAgeing, daysInMonthType, daysInYearType,
                 isInterestRecalculationEnabled, rescheduleStrategyMethod, interestRecalculationCompoundingMethod, restCalendarInstance,
                 recalculationFrequencyType, compoundingCalendarInstance, compoundingFrequencyType, principalThresholdForLastInstalment,
-                installmentAmountInMultiplesOf, preClosureInterestCalculationStrategy);
+                installmentAmountInMultiplesOf, preClosureInterestCalculationStrategy, loanCalendar);
     }
 
     public static LoanApplicationTerms assembleFrom(final ApplicationCurrency applicationCurrency, final Integer loanTermFrequency,
@@ -188,6 +191,29 @@ public final class LoanApplicationTerms {
             final RecalculationFrequencyType compoundingFrequencyType,
             final LoanPreClosureInterestCalculationStrategy loanPreClosureInterestCalculationStrategy,
             final LoanRescheduleStrategyMethod rescheduleStrategyMethod) {
+        final Calendar loanCalendar = null;
+
+        return assembleFrom(applicationCurrency, loanTermFrequency, loanTermPeriodFrequencyType, nthDay, dayOfWeek,
+                expectedDisbursementDate, repaymentsStartingFromDate, calculatedRepaymentsStartingFromDate, inArrearsTolerance,
+                loanProductRelatedDetail, multiDisburseLoan, emiAmount, disbursementDatas, maxOutstandingBalance, emiAmountVariations,
+                interestChargedFromDate, principalThresholdForLastInstalment, installmentAmountInMultiplesOf, recalculationFrequencyType,
+                restCalendarInstance, compoundingMethod, compoundingCalendarInstance, compoundingFrequencyType,
+                loanPreClosureInterestCalculationStrategy, rescheduleStrategyMethod, loanCalendar);
+    }
+
+    public static LoanApplicationTerms assembleFrom(final ApplicationCurrency applicationCurrency, final Integer loanTermFrequency,
+            final PeriodFrequencyType loanTermPeriodFrequencyType, NthDayType nthDay, DayOfWeekType dayOfWeek,
+            final LocalDate expectedDisbursementDate, final LocalDate repaymentsStartingFromDate,
+            final LocalDate calculatedRepaymentsStartingFromDate, final Money inArrearsTolerance,
+            final LoanProductRelatedDetail loanProductRelatedDetail, final boolean multiDisburseLoan, final BigDecimal emiAmount,
+            final List<DisbursementData> disbursementDatas, final BigDecimal maxOutstandingBalance,
+            final List<LoanTermVariationsData> emiAmountVariations, final LocalDate interestChargedFromDate,
+            final BigDecimal principalThresholdForLastInstalment, final Integer installmentAmountInMultiplesOf,
+            final RecalculationFrequencyType recalculationFrequencyType, final CalendarInstance restCalendarInstance,
+            final InterestRecalculationCompoundingMethod compoundingMethod, final CalendarInstance compoundingCalendarInstance,
+            final RecalculationFrequencyType compoundingFrequencyType,
+            final LoanPreClosureInterestCalculationStrategy loanPreClosureInterestCalculationStrategy,
+            final LoanRescheduleStrategyMethod rescheduleStrategyMethod, final Calendar loanCalendar) {
 
         final Integer numberOfRepayments = loanProductRelatedDetail.getNumberOfRepayments();
         final Integer repaymentEvery = loanProductRelatedDetail.getRepayEvery();
@@ -210,7 +236,6 @@ public final class LoanApplicationTerms {
         final DaysInMonthType daysInMonthType = loanProductRelatedDetail.fetchDaysInMonthType();
         final DaysInYearType daysInYearType = loanProductRelatedDetail.fetchDaysInYearType();
         final boolean isInterestRecalculationEnabled = loanProductRelatedDetail.isInterestRecalculationEnabled();
-
         return new LoanApplicationTerms(applicationCurrency, loanTermFrequency, loanTermPeriodFrequencyType, numberOfRepayments,
                 repaymentEvery, repaymentPeriodFrequencyType, nthDay.getValue(), dayOfWeek, amortizationMethod, interestMethod,
                 interestRatePerPeriod, interestRatePeriodFrequencyType, annualNominalInterestRate, interestCalculationPeriodMethod,
@@ -220,7 +245,7 @@ public final class LoanApplicationTerms {
                 loanProductRelatedDetail.getGraceOnDueDate(), daysInMonthType, daysInYearType, isInterestRecalculationEnabled,
                 rescheduleStrategyMethod, compoundingMethod, restCalendarInstance, recalculationFrequencyType, compoundingCalendarInstance,
                 compoundingFrequencyType, principalThresholdForLastInstalment, installmentAmountInMultiplesOf,
-                loanPreClosureInterestCalculationStrategy);
+                loanPreClosureInterestCalculationStrategy, loanCalendar);
     }
 
     public static LoanApplicationTerms assembleFrom(final ApplicationCurrency applicationCurrency, final Integer loanTermFrequency,
@@ -262,7 +287,7 @@ public final class LoanApplicationTerms {
             rescheduleStrategyMethod = interestRecalculationDetails.getRescheduleStrategyMethod();
             interestRecalculationCompoundingMethod = interestRecalculationDetails.getInterestRecalculationCompoundingMethod();
         }
-
+        final Calendar loanCalendar = null;
         return new LoanApplicationTerms(applicationCurrency, loanTermFrequency, loanTermPeriodFrequencyType, numberOfRepayments,
                 repaymentEvery, repaymentPeriodFrequencyType, null, null, amortizationMethod, interestMethod, interestRatePerPeriod,
                 interestRatePeriodFrequencyType, annualNominalInterestRate, interestCalculationPeriodMethod, principalMoney,
@@ -272,7 +297,7 @@ public final class LoanApplicationTerms {
                 daysInMonthType, daysInYearType, isInterestRecalculationEnabled, rescheduleStrategyMethod,
                 interestRecalculationCompoundingMethod, restCalendarInstance, recalculationFrequencyType, compoundingCalendarInstance,
                 compoundingFrequencyType, principalThresholdForLastInstalment, installmentAmountInMultiplesOf,
-                loanPreClosureInterestCalculationStrategy);
+                loanPreClosureInterestCalculationStrategy, loanCalendar);
     }
 
     public static LoanApplicationTerms assembleFrom(final Integer repaymentEvery, final PeriodFrequencyType repaymentPeriodFrequencyType,
@@ -292,7 +317,8 @@ public final class LoanApplicationTerms {
                 applicationTerms.interestRecalculationCompoundingMethod, applicationTerms.restCalendarInstance,
                 applicationTerms.recalculationFrequencyType, applicationTerms.compoundingCalendarInstance,
                 applicationTerms.compoundingFrequencyType, applicationTerms.principalThresholdForLastInstalment,
-                applicationTerms.installmentAmountInMultiplesOf, applicationTerms.preClosureInterestCalculationStrategy);
+                applicationTerms.installmentAmountInMultiplesOf, applicationTerms.preClosureInterestCalculationStrategy,
+                applicationTerms.loanCalendar);
     }
 
     private LoanApplicationTerms(final ApplicationCurrency currency, final Integer loanTermFrequency,
@@ -312,7 +338,7 @@ public final class LoanApplicationTerms {
             final CalendarInstance restCalendarInstance, final RecalculationFrequencyType recalculationFrequencyType,
             final CalendarInstance compoundingCalendarInstance, final RecalculationFrequencyType compoundingFrequencyType,
             final BigDecimal principalThresholdForLastInstalment, final Integer installmentAmountInMultiplesOf,
-            final LoanPreClosureInterestCalculationStrategy preClosureInterestCalculationStrategy) {
+            final LoanPreClosureInterestCalculationStrategy preClosureInterestCalculationStrategy, final Calendar loanCalendar) {
         this.currency = currency;
         this.loanTermFrequency = loanTermFrequency;
         this.loanTermPeriodFrequencyType = loanTermPeriodFrequencyType;
@@ -359,6 +385,8 @@ public final class LoanApplicationTerms {
         this.principalThresholdForLastInstalment = principalThresholdForLastInstalment;
         this.installmentAmountInMultiplesOf = installmentAmountInMultiplesOf;
         this.preClosureInterestCalculationStrategy = preClosureInterestCalculationStrategy;
+
+        this.loanCalendar = loanCalendar;
     }
 
     public Money adjustPrincipalIfLastRepaymentPeriod(final Money principalForPeriod, final Money totalCumulativePrincipalToDate,
@@ -1211,8 +1239,11 @@ public final class LoanApplicationTerms {
         return this.compoundingFrequencyType;
     }
 
-    
     public BigDecimal getActualFixedEmiAmount() {
         return this.actualFixedEmiAmount;
+    }
+
+    public Calendar getLoanCalendar() {
+        return loanCalendar;
     }
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/loanschedule/domain/LoanScheduleGenerator.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/loanschedule/domain/LoanScheduleGenerator.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import org.joda.time.LocalDate;
 import org.mifosplatform.organisation.monetary.domain.ApplicationCurrency;
 import org.mifosplatform.organisation.monetary.domain.MonetaryCurrency;
+import org.mifosplatform.portfolio.calendar.domain.Calendar;
 import org.mifosplatform.portfolio.calendar.domain.CalendarInstance;
 import org.mifosplatform.portfolio.loanaccount.data.HolidayDetailDTO;
 import org.mifosplatform.portfolio.loanaccount.domain.LoanCharge;
@@ -32,8 +33,10 @@ public interface LoanScheduleGenerator {
 
     LoanRepaymentScheduleInstallment calculatePrepaymentAmount(List<LoanRepaymentScheduleInstallment> installments,
             MonetaryCurrency currency, LocalDate onDate, LoanApplicationTerms loanApplicationTerms, MathContext mc,
-            Set<LoanCharge> charges, HolidayDetailDTO holidayDetailDTO, List<LoanTransaction> loanTransactions, LoanRepaymentScheduleTransactionProcessor loanRepaymentScheduleTransactionProcessor);
+            Set<LoanCharge> charges, HolidayDetailDTO holidayDetailDTO, List<LoanTransaction> loanTransactions,
+            LoanRepaymentScheduleTransactionProcessor loanRepaymentScheduleTransactionProcessor);
 
     LoanRescheduleModel reschedule(final MathContext mathContext, final LoanRescheduleRequest loanRescheduleRequest,
-            final ApplicationCurrency applicationCurrency, final HolidayDetailDTO holidayDetailDTO, CalendarInstance restCalendarInstance, CalendarInstance compoundingCalendarInstance);
+            final ApplicationCurrency applicationCurrency, final HolidayDetailDTO holidayDetailDTO, CalendarInstance restCalendarInstance,
+            CalendarInstance compoundingCalendarInstance, final Calendar loanCalendar);
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/loanschedule/domain/ScheduledDateGenerator.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/loanschedule/domain/ScheduledDateGenerator.java
@@ -17,7 +17,8 @@ public interface ScheduledDateGenerator {
     LocalDate idealDisbursementDateBasedOnFirstRepaymentDate(PeriodFrequencyType repaymentPeriodFrequencyType, int repaidEvery,
             final LocalDate firstRepaymentDate);
 
-    LocalDate generateNextRepaymentDate(LocalDate lastRepaymentDate, LoanApplicationTerms loanApplicationTerms, boolean isFirstRepayment);
+    LocalDate generateNextRepaymentDate(LocalDate lastRepaymentDate, LoanApplicationTerms loanApplicationTerms, boolean isFirstRepayment,
+            final HolidayDetailDTO holidayDetailDTO);
 
     LocalDate adjustRepaymentDate(LocalDate dueRepaymentPeriodDate, LoanApplicationTerms loanApplicationTerms,
             final HolidayDetailDTO holidayDetailDTO);

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/loanschedule/service/LoanScheduleAssembler.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/loanschedule/service/LoanScheduleAssembler.java
@@ -302,7 +302,7 @@ public class LoanScheduleAssembler {
                 loanProduct.isMultiDisburseLoan(), emiAmount, disbursementDatas, maxOutstandingBalance, loanVariationTermsData,
                 graceOnArrearsAgeing, daysInMonthType, daysInYearType, isInterestRecalculationEnabled, recalculationFrequencyType,
                 restCalendarInstance, compoundingCalendarInstance, compoundingFrequencyType, principalThresholdForLastInstalment,
-                installmentAmountInMultiplesOf, loanProduct.preCloseInterestCalculationStrategy());
+                installmentAmountInMultiplesOf, loanProduct.preCloseInterestCalculationStrategy(), calendar);
     }
 
     private CalendarInstance createInterestRecalculationCalendarInstance(final LocalDate calendarStartDate,

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/rescheduleloan/domain/DefaultLoanReschedulerFactory.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/rescheduleloan/domain/DefaultLoanReschedulerFactory.java
@@ -8,6 +8,7 @@ package org.mifosplatform.portfolio.loanaccount.rescheduleloan.domain;
 import java.math.MathContext;
 
 import org.mifosplatform.organisation.monetary.domain.ApplicationCurrency;
+import org.mifosplatform.portfolio.calendar.domain.Calendar;
 import org.mifosplatform.portfolio.calendar.domain.CalendarInstance;
 import org.mifosplatform.portfolio.loanaccount.data.HolidayDetailDTO;
 import org.mifosplatform.portfolio.loanaccount.loanschedule.domain.DecliningBalanceInterestLoanScheduleGenerator;
@@ -20,19 +21,19 @@ public class DefaultLoanReschedulerFactory implements LoanReschedulerFactory {
     public LoanRescheduleModel reschedule(final MathContext mathContext, final InterestMethod interestMethod,
             final LoanRescheduleRequest loanRescheduleRequest, final ApplicationCurrency applicationCurrency,
             final HolidayDetailDTO holidayDetailDTO, final CalendarInstance restCalendarInstance,
-            final CalendarInstance compoundingCalendarInstance) {
+            final CalendarInstance compoundingCalendarInstance, final Calendar loanCalendar) {
 
         LoanRescheduleModel loanRescheduleModel = null;
 
         switch (interestMethod) {
             case DECLINING_BALANCE:
                 loanRescheduleModel = new DecliningBalanceInterestLoanScheduleGenerator().reschedule(mathContext, loanRescheduleRequest,
-                        applicationCurrency, holidayDetailDTO, restCalendarInstance, compoundingCalendarInstance);
+                        applicationCurrency, holidayDetailDTO, restCalendarInstance, compoundingCalendarInstance, loanCalendar);
             break;
 
             case FLAT:
                 loanRescheduleModel = new FlatInterestLoanScheduleGenerator().reschedule(mathContext, loanRescheduleRequest,
-                        applicationCurrency, holidayDetailDTO, restCalendarInstance, compoundingCalendarInstance);
+                        applicationCurrency, holidayDetailDTO, restCalendarInstance, compoundingCalendarInstance, loanCalendar);
             break;
 
             case INVALID:

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/rescheduleloan/domain/LoanReschedulerFactory.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/rescheduleloan/domain/LoanReschedulerFactory.java
@@ -8,6 +8,7 @@ package org.mifosplatform.portfolio.loanaccount.rescheduleloan.domain;
 import java.math.MathContext;
 
 import org.mifosplatform.organisation.monetary.domain.ApplicationCurrency;
+import org.mifosplatform.portfolio.calendar.domain.Calendar;
 import org.mifosplatform.portfolio.calendar.domain.CalendarInstance;
 import org.mifosplatform.portfolio.loanaccount.data.HolidayDetailDTO;
 import org.mifosplatform.portfolio.loanproduct.domain.InterestMethod;
@@ -16,5 +17,6 @@ public interface LoanReschedulerFactory {
 
     public LoanRescheduleModel reschedule(final MathContext mathContext, final InterestMethod interestMethod,
             final LoanRescheduleRequest loanRescheduleRequest, final ApplicationCurrency applicationCurrency,
-            final HolidayDetailDTO holidayDetailDTO, CalendarInstance restCalendarInstance, CalendarInstance compoundingCalendarInstance);
+            final HolidayDetailDTO holidayDetailDTO, CalendarInstance restCalendarInstance, CalendarInstance compoundingCalendarInstance,
+            final Calendar loanCalendar);
 }

--- a/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/rescheduleloan/service/LoanReschedulePreviewPlatformServiceImpl.java
+++ b/mifosng-provider/src/main/java/org/mifosplatform/portfolio/loanaccount/rescheduleloan/service/LoanReschedulePreviewPlatformServiceImpl.java
@@ -18,6 +18,7 @@ import org.mifosplatform.organisation.monetary.domain.ApplicationCurrencyReposit
 import org.mifosplatform.organisation.monetary.domain.MonetaryCurrency;
 import org.mifosplatform.organisation.workingdays.domain.WorkingDays;
 import org.mifosplatform.organisation.workingdays.domain.WorkingDaysRepositoryWrapper;
+import org.mifosplatform.portfolio.calendar.domain.Calendar;
 import org.mifosplatform.portfolio.calendar.domain.CalendarEntityType;
 import org.mifosplatform.portfolio.calendar.domain.CalendarInstance;
 import org.mifosplatform.portfolio.calendar.domain.CalendarInstanceRepository;
@@ -92,9 +93,15 @@ public class LoanReschedulePreviewPlatformServiceImpl implements LoanRescheduleP
             compoundingCalendarInstance = calendarInstanceRepository.findCalendarInstaneByEntityId(
                     loan.loanInterestRecalculationDetailId(), CalendarEntityType.LOAN_RECALCULATION_COMPOUNDING_DETAIL.getValue());
         }
-
+        final CalendarInstance loanCalendarInstance = calendarInstanceRepository.findCalendarInstaneByEntityId(loan.getId(),
+                CalendarEntityType.LOANS.getValue());
+        Calendar loanCalendar = null;
+        if (loanCalendarInstance != null) {
+            loanCalendar = loanCalendarInstance.getCalendar();
+        }
         LoanRescheduleModel loanRescheduleModel = new DefaultLoanReschedulerFactory().reschedule(mathContext, interestMethod,
-                loanRescheduleRequest, applicationCurrency, holidayDetailDTO, restCalendarInstance, compoundingCalendarInstance);
+                loanRescheduleRequest, applicationCurrency, holidayDetailDTO, restCalendarInstance, compoundingCalendarInstance,
+                loanCalendar);
         LoanRescheduleModel loanRescheduleModelWithOldPeriods = LoanRescheduleModel.createWithSchedulehistory(loanRescheduleModel,
                 oldPeriods);
         return loanRescheduleModelWithOldPeriods;


### PR DESCRIPTION
Fixed 2 issues regarding loans that have repayment synked to group meetings :
1) After group meeting date changed, the expected maturity date remained the same
2) rescheduling a loan for which the group meeting date changed previously restored the repayment installations back to the original setup, instead of the new setup that depends on the new group meeting dates

Added integration test for these two bugs:
org.mifosplatform.integrationtests.DisbursalAndRepaymentScheduleTest