### PR TITLE
MIFOSX-2154: Fix the integration test for ExternalServicesConfigurati…

### DIFF
--- a/mifosng-provider/src/integrationTest/java/org/mifosplatform/integrationtests/ExternalServicesConfigurationTest.java
+++ b/mifosng-provider/src/integrationTest/java/org/mifosplatform/integrationtests/ExternalServicesConfigurationTest.java
@@ -52,6 +52,9 @@ public class ExternalServicesConfigurationTest {
             String value = null;
             if (name.equals(configName)) {
                 value = (String) externalServicesConfig.get(configIndex).get("value");
+                if(value == null){
+                    value = "testnull";
+                }
                 String newValue = "test";
                 System.out.println(name + ":" + value);
                 HashMap arrayListValue = this.externalServicesConfigurationHelper.updateValueForExternaServicesConfiguration(requestSpec,
@@ -77,6 +80,9 @@ public class ExternalServicesConfigurationTest {
             String value = null;
             if (name.equals(configName)) {
                 value = (String) externalServicesConfig.get(configIndex).get("value");
+                if(value == null){
+                    value = "testnull";
+                }
                 String newValue = "test";
                 System.out.println(name + ":" + value);
                 HashMap arrayListValue = this.externalServicesConfigurationHelper.updateValueForExternaServicesConfiguration(requestSpec,


### PR DESCRIPTION
The default value for the S3 configurations is null and thereby the null asserts were failing. Fixed.