### PR TITLE
Mifosx 1523   loan rescheduling

### DIFF
--- a/mifosng-provider/src/main/resources/sql/migrations/core_db/V274__Loan_Reschedule_Code_Value.sql
+++ b/mifosng-provider/src/main/resources/sql/migrations/core_db/V274__Loan_Reschedule_Code_Value.sql
@@ -1,0 +1,5 @@
+INSERT INTO `m_code` (`code_name`, `is_system_defined`) VALUES ('LoanRescheduleReason1', '1');
+
+
+
+	

--- a/mifosng-provider/src/main/resources/sql/migrations/core_db/V274__Loan_Reschedule_Code_Value.sql
+++ b/mifosng-provider/src/main/resources/sql/migrations/core_db/V274__Loan_Reschedule_Code_Value.sql
@@ -1,4 +1,4 @@
-INSERT INTO `m_code` (`code_name`, `is_system_defined`) VALUES ('LoanRescheduleReason1', '1');
+INSERT INTO `m_code` (`code_name`, `is_system_defined`) VALUES ('LoanRescheduleReason', '1');
 
 
 


### PR DESCRIPTION
Adding system defined code name for loan rescheduling reason

Known Issues;
1. Loan Rescheduling is not support for specified due date charges and tranche loans
2. Interest based on new terms doesn't have any effect on interest recalculations
3. After Undo disbursement and disbursement of loan not able to reschedule displays already rescheduled.
