### PR TITLE
fix for MIFOSX-2186

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/charge/domain/Charge.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/charge/domain/Charge.java
@@ -487,8 +487,8 @@ public class Charge extends AbstractPersistable<Long> {
 
         }
 
-        if (this.penalty && ChargeTimeType.fromInt(this.chargeTimeType)
-                .isTimeOfDisbursement()) { throw new ChargeDueAtDisbursementCannotBePenaltyException(this.name); }
+        if (this.penalty && (ChargeTimeType.fromInt(this.chargeTimeType)
+                .isTimeOfDisbursement() || ChargeTimeType.fromInt(this.chargeTimeType).isTrancheDisbursement())) { throw new ChargeDueAtDisbursementCannotBePenaltyException(this.name); }
         if (!penalty
                 && ChargeTimeType.fromInt(this.chargeTimeType).isOverdueInstallment()) { throw new ChargeMustBePenaltyException(name); }
 


### PR DESCRIPTION
per MIFOSX-2186 throw Cannot Be Penalty exception if changing a charge's chargeTimeType to Tranche Disbursement and penalty flag set to true.
