### PR TITLE
Fix broken links and update the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,52 +11,44 @@ Travis
 [![Build
 Status](https://travis-ci.org/openMF/mifosx.png?branch=master)](https://travis-ci.org/openMF/mifosx)
 
-Cloudbees Jenkins
-
-[![Build
-Status](https://openmf.ci.cloudbees.com/job/MIFOSX%20INTEGRATION%20TEST/badge/icon)](https://openmf.ci.cloudbees.com/job/MIFOSX%20INTEGRATION%20TEST/)
-
-<a target="_blank" href="https://openmf.ci.cloudbees.com/job/MIFOSX%20INTEGRATION%20TEST/"  title="Jenkins@CloudBees">Jenkins@CloudBees Unit + Integration Tests</a>
-
 
 Version
 ==========
 
-The API for the fineract-platform (project named 'Apache Fineract')is documented in the api-docs under <b>Full API Matrix</b> and can be viewed <a target="_blank" href="https://demo.openmf.org/api-docs/apiLive.htm" title="API Documentation"> here
+The API for the fineract-platform (project named 'Apache Fineract') is documented in the API-docs under <b>Full API Matrix</b> and can be viewed <a href="https://demo.openmf.org/api-docs/apiLive.htm" title="API Documentation"> here
 </a>
 
-Latest stable release can always been viewed on master branch: <a target="_blank" href="https://github.com/openMF/mifosx/tree/master" title="Latest Release">Latest Release on Master</a>, <a target="_blank" href="https://github.com/openMF/mifosx/blob/master/CHANGELOG.md" title="Latest release change log">View change log</a>
+The latest stable release can be viewed on the master branch: <a href="https://github.com/openMF/mifosx/tree/master" title="Latest Release">Latest Release on Master</a>, <a href="https://github.com/openMF/mifosx/blob/master/CHANGELOG.md" title="Latest release change log">View change log</a>
 
 License
 =============
 
-This project is licensed under the open source MPL V2. See https://github.com/openMF/mifosx/blob/master/LICENSE.md
+This project is licensed under open source MPL V2. See <https://github.com/openMF/mifosx/blob/master/LICENSE.md>
 
 Fineract Platform API
 =====================
 
-<a target="_blank" href="https://demo.openmf.org/api-docs/apiLive.htm" title="fineract platform api">API Documentation (Demo Server)</a>
+<a href="https://demo.openmf.org/api-docs/apiLive.htm" title="fineract platform api">API Documentation (Demo Server)</a>
 
 
 Online Demos
 =============================
 
-* <a target="_blank" href="https://demo.openmf.org" title="Reference Client App">Community App</a>
-* ~~<a target="_blank" href="https://demo.openmf.org/old/" title="Community App">Reference Client App (Deprecated)</a>~~
+* <a href="https://demo.openmf.org" title="Reference Client App">Community App</a>
 
 Developers
 ==========
-see https://mifosforge.jira.com/wiki/display/MIFOSX/MifosX+Technical - Developers Wiki Page
+Please see <https://mifosforge.jira.com/wiki/display/MDZ/Welcome+to+the+Zone> for the developers wiki page.
 
-see https://mifosforge.jira.com/wiki/display/MIFOSX/Getting+started+-+Contributing+to+MifosX  - Getting Started.
+Please see <https://mifosforge.jira.com/wiki/display/MDZ/Getting+started> to get started.
 
-see https://mifosforge.jira.com/wiki/display/MIFOSX/The+Basic+Design - Overview of Platform Implementation
+Please see <https://mifosforge.jira.com/wiki/display/MDZ/Understanding+platform%27s+technical+design> for an overview of our platform implementation.
 
-see https://github.com/openMF/mifosx/wiki/Screen-Based-Reporting for info around reporting
+Please see <https://github.com/openMF/mifosx/wiki/Screen-Based-Reporting> for information about reporting.
 
-see https://github.com/openMF/mifosx/wiki/Git-Usuage for info around using git
+Please see <https://github.com/openMF/mifosx/wiki/Git-Usage> for information about using Git.
 
-see https://www.ohloh.net/p/mifosx for activity overview and basic code analysis.
+Please see <https://www.ohloh.net/p/mifosx> for an activity overview and basic code analysis.
 
 Roadmap
 ==============
@@ -69,4 +61,4 @@ Roadmap
 Video Demonstration
 ===============
 
-Demonstration of first Prototype of this platform with browser App (April 2012) - http://www.youtube.com/watch?v=zN5Dn1Lc_js
+Mifos X 16.01 Showcase (January 2016) - <https://www.youtube.com/watch?v=REfDkjGfeq8>


### PR DESCRIPTION
* Removed Jenkins Cloudbees (No longer in use)
* Deleted Reference Client App Link (broken and deprecated)
* Updated links for the developers, platform implementation, and git sections
* Updated link for the demo video
* Improved the wording and grammar
* Removed target='_blank' as that is not supported
* Enclosed bare links in <> specified by Markdown language

You can preview the new implementation here:
https://github.com/mdew192837/mifosx/tree/FixBrokenLinks