### PR TITLE
Fix broken links and update the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Mifos X: A Platform for Microfinance
 ======
 
-The next evolution of mifos focussing being faster, lighter and cheaper to change (than existing mifos) so that it is more responsive to the needs of MFI’s and Integrators
+The next evolution of Mifos focuses on being faster, lighter and cheaper to change (than the existing Mifos) so that it is more responsive to the needs of Microfinance Institutions and Integrators.
 
 Build Status
 ============
@@ -11,62 +11,52 @@ Travis
 [![Build
 Status](https://travis-ci.org/openMF/mifosx.png?branch=master)](https://travis-ci.org/openMF/mifosx)
 
-Cloudbees Jenkins
-
-[![Build
-Status](https://openmf.ci.cloudbees.com/job/MIFOSX%20INTEGRATION%20TEST/badge/icon)](https://openmf.ci.cloudbees.com/job/MIFOSX%20INTEGRATION%20TEST/)
-
-<a target="_blank" href="https://openmf.ci.cloudbees.com/job/MIFOSX%20INTEGRATION%20TEST/"  title="Jenkins@CloudBees">Jenkins@CloudBees Unit + Integration Tests</a>
-
 
 Version
 ==========
 
-The API for the mifos-platform (project named 'Mifos X')is documented in the api-docs under <b>Full API Matrix</b> and can be viewed <a target="_blank" href="https://demo.openmf.org/api-docs/apiLive.htm" title="API Documentation"> here
-</a>
+The API for the Mifos-platform (project named 'Mifos X') is documented in the API-docs under <b>Full API Matrix</b> and can be viewed [here](https://demo.openmf.org/api-docs/apiLive.htm "API Documentation").
 
-Latest stable release can always been viewed on master branch: <a target="_blank" href="https://github.com/openMF/mifosx/tree/master" title="Latest Release">Latest Release on Master</a>, <a target="_blank" href="https://github.com/openMF/mifosx/blob/master/CHANGELOG.md" title="Latest release change log">View change log</a>
+The latest stable release can be viewed on the master branch: [Latest Release on Master](https://github.com/openMF/mifosx/tree/master "Latest Release"), [View change log](https://github.com/openMF/mifosx/blob/master/CHANGELOG.md "Latest release change log")
 
 License
 =============
 
-This project is licensed under the open source MPL V2. See https://github.com/openMF/mifosx/blob/master/LICENSE.md
+This project is licensed under open source MPL V2. See <https://github.com/openMF/mifosx/blob/master/LICENSE.md>.
 
-Mifos Platform API
+Mifos X Platform API
 =====================
 
-<a target="_blank" href="https://demo.openmf.org/api-docs/apiLive.htm" title="mifos platform api">API Documentation (Demo Server)</a>
+[API Documentation (Demo Server)](https://demo.openmf.org/api-docs/apiLive.htm "Mifos platform API")
 
 
 Online Demos
 =============================
 
-* <a target="_blank" href="https://demo.openmf.org" title="Reference Client App">Community App</a>
-* ~~<a target="_blank" href="https://demo.openmf.org/old/" title="Community App">Reference Client App (Deprecated)</a>~~
+* [Community App](https://demo.openmf.org "Reference Client App")
 
 Developers
 ==========
-see https://mifosforge.jira.com/wiki/display/MIFOSX/MifosX+Technical - Developers Wiki Page
+Please see <https://mifosforge.jira.com/wiki/display/MDZ/Welcome+to+the+Zone> for the developers wiki page.
 
-see https://mifosforge.jira.com/wiki/display/MIFOSX/Getting+started+-+Contributing+to+MifosX  - Getting Started.
+Please see <https://mifosforge.jira.com/wiki/display/MDZ/Getting+started> to get started.
 
-see https://mifosforge.jira.com/wiki/display/MIFOSX/The+Basic+Design - Overview of Platform Implementation
+Please see <https://mifosforge.jira.com/wiki/display/MDZ/Understanding+platform%27s+technical+design> for an overview of our platform implementation.
 
-see https://github.com/openMF/mifosx/wiki/Screen-Based-Reporting for info around reporting
+Please see <https://github.com/openMF/mifosx/wiki/Screen-Based-Reporting> for information about reporting.
 
-see https://github.com/openMF/mifosx/wiki/Git-Usuage for info around using git
+Please see <https://github.com/openMF/mifosx/wiki/Git-Usage> for information about using Git.
 
-see https://www.ohloh.net/p/mifosx for activity overview and basic code analysis.
+Please see <https://www.ohloh.net/p/mifosx> for an activity overview and basic code analysis.
 
 Roadmap
 ==============
 
-<a target="_blank" href="http://goo.gl/IXS9Q" title="Community Roadmap (High Level)">Community Roadmap (High Level)</a>
+[Community Roadmap (High Level)](http://goo.gl/IXS9Q "Community Roadmap (High Level)")
 
-<a target="_blank" href="https://mifosforge.jira.com/browse/MIFOSX#selectedTab=com.atlassian.jira.plugin.system.project%3Aroadmap-panel" 
-   title="Project Release Roadmap on JIRA (Detailed View)">Project Release Roadmap on JIRA (Detailed View)</a>
+[Project Release Roadmap on JIRA (Detailed View)](https://mifosforge.jira.com/browse/MIFOSX#selectedTab=com.atlassian.jira.plugin.system.project%3Aroadmap-panel "Project Release Roadmap on JIRA (Detailed View)")
 
 Video Demonstration
 ===============
 
-Demonstration of first Prototype of this platform with browser App (April 2012) - http://www.youtube.com/watch?v=zN5Dn1Lc_js
+Mifos X 16.01 Showcase (January 2016) - <https://www.youtube.com/watch?v=REfDkjGfeq8>


### PR DESCRIPTION
* Removed Jenkins Cloudbees (No longer in use)
* Deleted Reference Client App Link (broken and deprecated)
* Updated links for the developers, platform implementation, and git sections
* Updated link for the demo video
* Improved the wording and grammar
* Removed target='_blank' as that is not supported
* Enclosed bare links in <> specified by Markdown language
* Capitalize Mifos
* Changed Mifos Platform API -> Mifos X Platform API
* Changed MFIs -> Microfinance Institutions
* Added some necessary periods.

You can preview the new implementation here:
https://github.com/mdew192837/mifosx/tree/FixBrokenLinksMaster